### PR TITLE
chore(dev.yml): update fixers-gradle workflows to use the main branch…

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@95e42b46a5478f10789f3e293c8ebc01d86e24b0
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write
@@ -30,7 +30,7 @@ jobs:
       PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@95e42b46a5478f10789f3e293c8ebc01d86e24b0
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
… instead of a specific commit hash

chore(dev.yml): update fixers-gradle workflows to use the main branch instead of a specific commit hash The fixers-gradle workflows in the dev.yml file have been updated to use the main branch instead of a specific commit hash. This ensures that the latest version of the workflows are used, providing any bug fixes or improvements that may have been made since the previous commit hash.