### PR TITLE
add observability opentelemetry module

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -36,6 +36,11 @@ object Versions {
 		const val slf4j = FixersVersions.Logging.slf4j
 	}
 
+	object Observability {
+		const val micrometer = "1.2.2"
+		const val micrometerOtlp = "1.12.3"
+		const val opentelemetry = "1.34.1"
+	}
 	const val cucumber = FixersVersions.Test.cucumber
 	const val springdoc = "1.6.11"
 	const val rsocket = "0.15.4"
@@ -59,7 +64,7 @@ object Dependencies {
 
 		object Test {
 			fun junit(scope: Scope) = FixersDependencies.Jvm.Test.junit(scope)
-			fun springTest(scope: Scope) =  scope.add(
+			fun springTest(scope: Scope) = junit(scope).add(
 				"org.springframework.boot:spring-boot-starter-test:${Versions.Spring.boot}"
 			)
 		}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,8 @@ include(
 include(
 	"f2-spring:function:f2-spring-boot-starter-function",
 	"f2-spring:function:f2-spring-boot-starter-function-http",
-	"f2-spring:function:f2-spring-boot-starter-function-rsocket"
+	"f2-spring:function:f2-spring-boot-starter-function-rsocket",
+	"f2-spring:function:f2-spring-boot-starter-observability-otel"
 )
 
 include(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,11 +25,12 @@ include(
 	"f2-spring:auth:f2-spring-boot-starter-auth-keycloak",
 )
 
-include(
-	"f2-spring:data:f2-spring-data",
-	"f2-spring:data:f2-spring-data-mongodb",
-	"f2-spring:data:f2-spring-data-mongodb-test"
-)
+// TODO: Disable data need before removing it
+//include(
+//	"f2-spring:data:f2-spring-data",
+//	"f2-spring:data:f2-spring-data-mongodb",
+//	"f2-spring:data:f2-spring-data-mongodb-test"
+//)
 
 include(
 	"f2-spring:exception:f2-spring-boot-exception-http",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,4 @@ sonar.sources=.
 sonar.language=kotlin
 sonar.kotlin.detekt.reportPaths=detekt.yml
 sonar.exclusions=**/*.java
+sonar.pullrequest.github.summary_comment=true


### PR DESCRIPTION
…-starter-observability-otel module

feat(f2-spring-boot-starter-observability-otel): add support for observability in the f2-spring-boot-starter-observability-otel module feat(OtelPropertiesListener): add OtelPropertiesListener class to handle setting management properties for observability feat(spring.factories): add OtelPropertiesListener as an ApplicationListener in spring.factories test(OtelPropertiesListenerTest): add tests for OtelPropertiesListener class to ensure correct initialization of management properties The changes include adding observability dependencies to the Dependencies.kt file for the f2-spring-boot-starter-observability-otel module. The build.gradle.kts file is also added for the f2-spring-boot-starter-observability-otel module. The OtelPropertiesListener class is added to handle setting management properties for observability. The spring.factories file is updated to include OtelPropertiesListener as an ApplicationListener. OtelPropertiesListenerTest is added to test the initialization of management properties.