### PR TITLE
fix(settings.gradle.kts): update dependency name from f2-spring-boot-…

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,7 @@ include(
 	"f2-spring:function:f2-spring-boot-starter-function",
 	"f2-spring:function:f2-spring-boot-starter-function-http",
 	"f2-spring:function:f2-spring-boot-starter-function-rsocket",
-	"f2-spring:function:f2-spring-boot-starter-observability-otel"
+	"f2-spring:function:f2-spring-boot-starter-observability-opentelemetry"
 )
 
 include(


### PR DESCRIPTION
…starter-observability-otel to f2-spring-boot-starter-observability-opentelemetry for consistency

The dependency name was updated to f2-spring-boot-starter-observability-opentelemetry to maintain consistency with the naming conventions used in the project.