### PR TITLE
feat(build): add support for OpenTelemetry properties configuration in F2 module

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -92,6 +92,11 @@ object Dependencies {
 				"org.springframework.boot:spring-boot-autoconfigure:${Versions.Spring.boot}"
 			)
 
+
+			fun configurationProcessor(scope: Scope) = scope.add(
+				"org.springframework.boot:spring-boot-configuration-processor"
+			)
+
 			fun cloudFunctionDep(scope: Scope) = scope.add(
 				"com.google.code.gson:gson:${Versions.Json.gson}",
 				"io.cloudevents:cloudevents-spring:${Versions.CloudEvent.spring}",

--- a/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/build.gradle.kts
+++ b/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("io.komune.fixers.gradle.kotlin.jvm")
+    id("io.komune.fixers.gradle.publish")
+    kotlin("kapt")
+}
+
+dependencies {
+    Dependencies.Jvm.Spring.configurationProcessor(::kapt)
+
+    api("org.springframework.boot:spring-boot-starter-actuator:${Versions.Spring.boot}")
+
+    api("io.micrometer:micrometer-tracing-bridge-otel:${Versions.Observability.micrometer}")
+
+    // OtlpTracingConfigurations.Exporters.otlpHttpSpanExporter => management.otlp.tracing.endpoint
+    implementation ("io.opentelemetry:opentelemetry-exporter-otlp:${Versions.Observability.opentelemetry}")
+
+    // FOR OtlpMetricsExportAutoConfiguration => management.otlp.metrics.export.url
+    implementation("io.micrometer:micrometer-registry-otlp:${Versions.Observability.micrometerOtlp}")
+
+    Dependencies.Jvm.Test.springTest(::implementation)
+}

--- a/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/kotlin/f2/spring/observability/opentelemetry/F2OpenTelemetryProperties.kt
+++ b/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/kotlin/f2/spring/observability/opentelemetry/F2OpenTelemetryProperties.kt
@@ -1,0 +1,48 @@
+package f2.spring.observability.opentelemetry
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Defines OpenTelemetry properties specific to a feature or module "F2".
+ * If the endpoint is set, it automatically configures metrics.endpoint to `${endpoint}/metrics`
+ * and traces.endpoint to `${endpoint}/trace`.
+ */
+@ConfigurationProperties(prefix = OtelPropertiesListener.F2_OTEL_PREFIX)
+class F2OpenTelemetryProperties (
+    /**
+     * Optional String to specify the endpoint for OpenTelemetry. Null if not specified.
+     */
+    val endpoint: String?
+) {
+    /**
+     * Properties related to OpenTelemetry metrics.
+     */
+    val metrics: F2OpenTelemetryMetricsProperties = F2OpenTelemetryMetricsProperties(endpoint?.let { "$it/metrics" })
+
+    /**
+     * Properties related to OpenTelemetry traces.
+     */
+    val traces: F2OpenTelemetryTracesProperties = F2OpenTelemetryTracesProperties(endpoint?.let { "$it/trace" })
+}
+
+/**
+ * Properties for OpenTelemetry metrics specific to "F2".
+ */
+data class F2OpenTelemetryMetricsProperties(
+    /**
+     * Specifies the metrics endpoint for OpenTelemetry.
+     * Defaults to `${parentEndpoint}/metrics` if parent endpoint is set.
+     */
+    val endpoint: String?
+)
+
+/**
+ * Properties for OpenTelemetry traces specific to "F2".
+ */
+data class F2OpenTelemetryTracesProperties(
+    /**
+     * Specifies the traces endpoint for OpenTelemetry.
+     * Defaults to `${parentEndpoint}/trace` if parent endpoint is set.
+     */
+    val endpoint: String?
+)

--- a/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/kotlin/f2/spring/observability/opentelemetry/OtelPropertiesListener.kt
+++ b/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/kotlin/f2/spring/observability/opentelemetry/OtelPropertiesListener.kt
@@ -1,0 +1,57 @@
+package f2.spring.observability.opentelemetry
+
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.core.env.PropertiesPropertySource
+import java.util.*
+
+
+class OtelPropertiesListener: ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+    companion object {
+        const val F2_OTEL_PROPS = "f2OtelProps"
+        const val F2_OTEL_METRICS_ENDPOINT_PATH = "/v1/metrics"
+        const val F2_OTEL_TRACES_ENDPOINT_PATH = "/v1/traces"
+
+        const val F2_OTEL_PREFIX = "f2.observability.opentelemetry"
+        const val F2_OTEL_ENDPOINT = "$F2_OTEL_PREFIX.endpoint"
+        const val F2_OTEL_METRICS_ENDPOINT = "$F2_OTEL_PREFIX.metrics.endpoint"
+        const val F2_OTEL_TRACES_ENDPOINT = "$F2_OTEL_PREFIX.traces.endpoint"
+        const val SPRING_APPLICATION_NAME = "spring.application.name"
+
+        const val MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE = "management.endpoints.web.exposure.include"
+        const val MANAGEMENT_ENDPOINT_METRICS_ENABLED = "management.endpoint.metrics.enabled"
+        const val MANAGEMENT_TRACING_SAMPLING_PROBABILITY = "management.tracing.sampling.probability"
+        const val MANAGEMENT_OTLP_TRACING_ENDPOINT = "management.otlp.tracing.endpoint"
+        const val MANAGEMENT_OTLP_METRICS_EXPORT_URL = "management.otlp.metrics.export.url"
+        const val MANAGEMENT_METRICS_TAGS_APPLICATION = "management.metrics.tags.application"
+    }
+
+    override fun onApplicationEvent(event: ApplicationEnvironmentPreparedEvent) {
+        val environment = event.environment
+
+        val mainEndpoint = environment.getProperty(F2_OTEL_ENDPOINT)
+        val metricsEndpoint = environment.getProperty(F2_OTEL_METRICS_ENDPOINT) ?:
+            mainEndpoint?.takeIf { it.isNotBlank() }?.plus(F2_OTEL_METRICS_ENDPOINT_PATH)
+
+        val tracingEndpoint = environment.getProperty(F2_OTEL_TRACES_ENDPOINT) ?:
+            mainEndpoint?.takeIf { it.isNotBlank() }?.plus(F2_OTEL_TRACES_ENDPOINT_PATH)
+
+        val application = environment.getProperty(SPRING_APPLICATION_NAME)
+
+        val props = Properties()
+        if(tracingEndpoint != null || metricsEndpoint != null) {
+            props[MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE] = "health, metrics"
+            props[MANAGEMENT_ENDPOINT_METRICS_ENABLED] = "true"
+            props[MANAGEMENT_TRACING_SAMPLING_PROBABILITY] = "1.0"
+            props[MANAGEMENT_METRICS_TAGS_APPLICATION] = application
+        }
+        if(tracingEndpoint != null) {
+            props[MANAGEMENT_OTLP_TRACING_ENDPOINT] = tracingEndpoint
+        }
+        if(metricsEndpoint != null) {
+            props[MANAGEMENT_OTLP_METRICS_EXPORT_URL] = metricsEndpoint
+        }
+        environment.propertySources.addFirst(PropertiesPropertySource(F2_OTEL_PROPS, props))
+    }
+}

--- a/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/resources/META-INF/spring.factories
+++ b/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.context.ApplicationListener=f2.spring.otel.OtelPropertiesListener

--- a/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/test/kotlin/f2/spring/observability/opentelemetry/OtelPropertiesListenerTest.kt
+++ b/f2-spring/function/f2-spring-boot-starter-observability-opentelemetry/src/test/kotlin/f2/spring/observability/opentelemetry/OtelPropertiesListenerTest.kt
@@ -1,0 +1,99 @@
+package f2.spring.observability.opentelemetry
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.ConfigurableApplicationContext
+
+class OtelPropertiesListenerTest {
+
+    companion object {
+        const val SPRING_APPLICATION_NAME = "spring.application.name"
+        const val SPRING_APPLICATION_NAME_VALUE = "myTestApp"
+        const val SPRING_APPLICATION_NAME_PROPERTIES = "$SPRING_APPLICATION_NAME=$SPRING_APPLICATION_NAME_VALUE"
+    }
+
+    @SpringBootApplication
+    open class App
+
+    @Test
+    fun springManagementContextShouldBeSet() {
+        val context = SpringApplicationBuilder(App::class.java)
+            .sources(OtelPropertiesListener::class.java)
+            .properties(
+                "${OtelPropertiesListener.F2_OTEL_METRICS_ENDPOINT}=http://test-tracing-endpoint:4318/v1/metrics",
+                "${OtelPropertiesListener.F2_OTEL_TRACES_ENDPOINT}=http://test-tracing-endpoint:4318/v1/traces",
+                SPRING_APPLICATION_NAME_PROPERTIES
+            ).run()
+
+        context.assertThatPropertiesAreSet()
+        context.assertThatBeanAreCreated()
+    }
+
+    @Test
+    fun f2OtelEndpointShouldInitTracesAndMetrics() {
+        val context = SpringApplicationBuilder(App::class.java)
+            .sources(OtelPropertiesListener::class.java)
+            .properties(
+                "f2.otel.endpoint=http://test-tracing-endpoint:4318",
+                SPRING_APPLICATION_NAME_PROPERTIES
+            )
+            .run()
+        context.assertThatPropertiesAreSet()
+        context.assertThatBeanAreCreated()
+
+    }
+
+    private fun ConfigurableApplicationContext.assertThatPropertiesAreSet() {
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE))
+            .isEqualTo("health, metrics")
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_ENDPOINT_METRICS_ENABLED))
+            .isEqualTo("true")
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_TRACING_SAMPLING_PROBABILITY))
+            .isEqualTo("1.0")
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_OTLP_TRACING_ENDPOINT))
+            .isEqualTo("http://test-tracing-endpoint:4318/v1/traces")
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_OTLP_METRICS_EXPORT_URL))
+            .isEqualTo("http://test-tracing-endpoint:4318/v1/metrics")
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_METRICS_TAGS_APPLICATION))
+            .isEqualTo("myTestApp")
+    }
+    private fun ConfigurableApplicationContext.assertThatBeanAreCreated() {
+        assertThat(getBean(SdkTracerProvider::class.java)).isNotNull
+        assertThat(getBean(OtlpHttpSpanExporter::class.java)).isNotNull
+    }
+
+
+    @Test
+    fun f2OtelShouldNotBePutIfPropsAreEmpty() {
+        val context = SpringApplicationBuilder(App::class.java)
+            .sources(OtelPropertiesListener::class.java)
+            .properties(
+                SPRING_APPLICATION_NAME_PROPERTIES
+            ).run()
+
+        val environment = context.environment
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE))
+            .isNull()
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_ENDPOINT_METRICS_ENABLED))
+            .isNull()
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_TRACING_SAMPLING_PROBABILITY))
+            .isNull()
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_OTLP_TRACING_ENDPOINT))
+            .isNull()
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_OTLP_METRICS_EXPORT_URL))
+            .isNull()
+        assertThat(environment.getProperty(OtelPropertiesListener.MANAGEMENT_METRICS_TAGS_APPLICATION))
+            .isNull()
+
+        assertThatThrownBy {
+            context.getBean(OtlpHttpSpanExporter::class.java)
+        }.isInstanceOf(NoSuchBeanDefinitionException::class.java)
+
+    }
+}


### PR DESCRIPTION


The Dependencies.kt file now includes a new function `configurationProcessor` to add the "org.springframework.boot:spring-boot-configuration-processor" dependency. This change allows for the configuration of OpenTelemetry properties specific to the F2 module.

A new build.gradle.kts file is added for the f2-spring-boot-starter-observability-opentelemetry module. This file includes dependencies related to OpenTelemetry, such as micrometer and opentelemetry exporters.

New Kotlin files are added for defining OpenTelemetry properties specific to the F2 module, including F2OpenTelemetryProperties, F2OpenTelemetryMetricsProperties, and F2OpenTelemetryTracesProperties.

Additionally, a new OtelPropertiesListener.kt file is added to handle the application of OpenTelemetry properties based on the environment configuration.

Lastly, a new spring.factories file is added to register the OtelPropertiesListener as an ApplicationListener for the Spring application context.

These changes enable the configuration of OpenTelemetry properties specific to the F2 module, enhancing observability capabilities within the application.