### PR TITLE
Add new module f2-spring-boot-starter-auth-tenant for multitenant auth

### DIFF
--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
@@ -1,0 +1,18 @@
+import io.komune.gradle.dependencies.Scope
+import io.komune.gradle.dependencies.add
+
+plugins {
+    id("io.komune.fixers.gradle.kotlin.jvm")
+    id("io.komune.fixers.gradle.publish")
+    kotlin("plugin.spring")
+    kotlin("kapt")
+}
+
+dependencies {
+    Dependencies.Jvm.Spring.configurationProcessor(::kapt)
+    Dependencies.Jvm.Spring.security(::api)
+    Dependencies.Jvm.Spring.oauth2(::api)
+//    Dependencies.Jvm.Spring.autoconfigure(::implementation)
+}
+
+

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProvider.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProvider.kt
@@ -1,0 +1,52 @@
+package io.komune.f2.spring.boot.auth
+
+import io.komune.f2.spring.boot.auth.config.WebSecurityConfig
+import kotlinx.coroutines.reactor.ReactorContext
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import reactor.core.publisher.Mono
+import kotlin.coroutines.coroutineContext
+
+const val ORGANIZATION_ID_CLAIM_NAME = "memberOf"
+const val AZP_CLAIM_NAME = "azp"
+
+object AuthenticationProvider {
+    suspend fun getSecurityContext(): SecurityContext? {
+        return coroutineContext[ReactorContext.Key]
+            ?.context?.get<Mono<SecurityContext>>(SecurityContext::class.java)
+            ?.awaitSingleOrNull()
+    }
+
+    suspend fun getAuthentication(): JwtAuthenticationToken? {
+        return getSecurityContext()?.authentication as JwtAuthenticationToken?
+    }
+
+    suspend fun getPrincipal(): Jwt? {
+        return getAuthentication()?.principal as Jwt?
+    }
+
+    suspend fun getOrganizationId(): String? {
+        return getPrincipal()?.getClaim<String>(ORGANIZATION_ID_CLAIM_NAME)
+    }
+
+    suspend fun getIssuer(): String? {
+        return getPrincipal()?.issuer?.toString()
+    }
+
+    suspend fun getClientId(): String? {
+        return getPrincipal()?.getClaim<String>(AZP_CLAIM_NAME)
+    }
+
+    suspend fun getSpace(): String? {
+        return getIssuer()?.substringAfterLast("/", "")?.ifEmpty { null }
+    }
+
+    suspend fun hasRole(role: String): Boolean {
+        return SimpleGrantedAuthority("${WebSecurityConfig.ROLE_PREFIX}$role") in getAuthentication()
+            ?.authorities
+            .orEmpty()
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluator.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluator.kt
@@ -1,0 +1,19 @@
+package io.komune.f2.spring.boot.auth
+
+import io.komune.f2.spring.boot.auth.AuthenticationProvider.hasRole
+import org.springframework.stereotype.Service
+
+const val ROLE_PREFIX = "ROLE_"
+const val SUPER_ADMIN_ROLE = "super_admin"
+
+@Service
+class PermissionEvaluator{
+    suspend fun isSuperAdmin(): Boolean {
+        return hasRole(ROLE_PREFIX + SUPER_ADMIN_ROLE)
+    }
+
+    suspend fun checkOrganizationId(organizationId: String?): Boolean {
+        if (organizationId == null) return false
+        return AuthenticationProvider.getOrganizationId() == organizationId
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/ConfigurationConstants.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/ConfigurationConstants.kt
@@ -1,0 +1,10 @@
+package io.komune.f2.spring.boot.auth.config
+
+// properties
+const val JWT_ISSUER_NAME = "f2.tenant.issuer-base-uri"
+
+// conditional expressions
+const val OPENID_REQUIRED_EXPRESSION = "!'\${$JWT_ISSUER_NAME:}'.isEmpty()"
+
+const val AUTHENTICATION_REQUIRED_EXPRESSION = "($OPENID_REQUIRED_EXPRESSION)"
+const val NO_AUTHENTICATION_REQUIRED_EXPRESSION = "!($AUTHENTICATION_REQUIRED_EXPRESSION)"

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfig.kt
@@ -1,0 +1,8 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "f2.tenant")
+data class F2TrustedIssuersConfig (
+    val issuerBaseUri: String
+)

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
@@ -1,0 +1,163 @@
+package io.komune.f2.spring.boot.auth.config
+
+import io.komune.f2.spring.boot.auth.security.TrustedIssuerJwtAuthenticationManagerResolver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authorization.AuthorizationDecision
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerReactiveAuthenticationManagerResolver
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter
+import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authorization.AuthorizationContext
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+
+@Suppress("UnnecessaryAbstractClass")
+@Configuration
+@ConditionalOnMissingBean(WebSecurityConfig::class)
+@EnableConfigurationProperties(F2TrustedIssuersConfig::class)
+abstract class WebSecurityConfig {
+
+    companion object {
+        const val SPRING_SECURITY_FILTER_CHAIN = "springSecurityFilterChain"
+        const val ROLE_PREFIX = "ROLE_"
+    }
+
+    @Value("\${spring.cloud.function.web.path:}")
+    lateinit var contextPath: String
+
+    @Autowired
+    lateinit var applicationContext: ApplicationContext
+
+    @Autowired
+    lateinit var f2TrustedIssuersResolver: F2TrustedIssuersConfig
+
+    @Bean
+    @ConfigurationProperties(prefix = "f2.filter")
+    fun authFilter(): Map<String, String> = HashMap()
+
+//    @Bean
+//    fun trustedIssuers(): List<String> {
+//        return f2TrustedIssuersResolver.getTrustedIssuers()
+//    }
+
+    @Bean(SPRING_SECURITY_FILTER_CHAIN)
+    @ConditionalOnExpression(NO_AUTHENTICATION_REQUIRED_EXPRESSION)
+    fun dummyAuthenticationProvider(http: ServerHttpSecurity): SecurityWebFilterChain {
+        http.authorizeExchange{ exchange ->
+            exchange.anyExchange().permitAll()
+        }
+        http.csrf { csrf ->
+            csrf.disable()
+        }
+        http.corsConfig()
+        return http.build()
+    }
+
+    @Bean(SPRING_SECURITY_FILTER_CHAIN)
+    @ConditionalOnExpression(AUTHENTICATION_REQUIRED_EXPRESSION)
+    fun oauthAuthenticationProvider(http: ServerHttpSecurity): SecurityWebFilterChain {
+        addAuthenticationRules(http)
+        http.csrf { csrf ->
+            csrf.disable()
+        }
+        http.corsConfig()
+        return http.build()
+    }
+
+    fun addAuthenticationRules(http: ServerHttpSecurity) {
+        addRolesAllowedRules(http)
+        addPermitAllRules(http)
+        addMandatoryAuthRules(http)
+        addJwtParsingRules(http)
+    }
+
+    private fun authenticate(
+        authentication: Mono<Authentication>
+    ): Mono<AuthorizationDecision> {
+        return authentication.map { auth ->
+            if (auth !is JwtAuthenticationToken || auth.token == null) {
+                return@map false
+            }
+
+            val filters = authFilter()
+            filters.isEmpty() || filters.all { (key, value) -> auth.token.claims[key] == value }
+        }.map(::AuthorizationDecision)
+    }
+
+    private fun ServerHttpSecurity.corsConfig() {
+        val config = CorsConfiguration()
+        config.allowedOrigins = listOf("*")
+        config.allowCredentials = false
+        config.addAllowedMethod("*")
+        config.addAllowedHeader("*")
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", config)
+        cors { spec ->
+            spec.configurationSource(source)
+        }
+    }
+
+    fun addRolesAllowedRules(http: ServerHttpSecurity) {
+        applicationContext.getBeanNamesForAnnotation(RolesAllowed::class.java)
+            .associateWith { bean ->
+                applicationContext.findAnnotationOnBean(bean, RolesAllowed::class.java)!!.value
+            }
+            .forEach { (name, roles) ->
+                http.authorizeExchange{ exchange ->
+                    exchange.pathMatchers("$contextPath/$name")
+                        .hasAnyRole(*roles)
+                }
+            }
+    }
+
+    fun addPermitAllRules(http: ServerHttpSecurity) {
+        val permitAllBeans = applicationContext.getBeanNamesForAnnotation(PermitAll::class.java)
+            .map { bean -> "$contextPath/$bean" }
+            .toTypedArray()
+
+        if (permitAllBeans.isNotEmpty()) {
+            http.authorizeExchange { exchange ->
+                exchange.pathMatchers(*permitAllBeans).permitAll()
+            }
+        }
+    }
+
+    fun addMandatoryAuthRules(http: ServerHttpSecurity) {
+        http.authorizeExchange { exchange ->
+            exchange.anyExchange()
+                .access { authentication, _ ->
+                    authenticate(authentication)
+                }
+        }
+    }
+
+    fun addJwtParsingRules(http: ServerHttpSecurity) {
+        val trustedIssuerJwtAuthenticationManagerResolver = TrustedIssuerJwtAuthenticationManagerResolver(
+            f2TrustedIssuersResolver
+        )
+        http.oauth2ResourceServer { oauth2 ->
+            oauth2.authenticationManagerResolver(
+                JwtIssuerReactiveAuthenticationManagerResolver(trustedIssuerJwtAuthenticationManagerResolver)
+            )
+        }
+    }
+
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
@@ -1,0 +1,58 @@
+package io.komune.f2.spring.boot.auth.security
+
+import io.komune.f2.spring.boot.auth.config.F2TrustedIssuersConfig
+import io.komune.f2.spring.boot.auth.config.WebSecurityConfig
+import org.springframework.security.authentication.ReactiveAuthenticationManager
+import org.springframework.security.authentication.ReactiveAuthenticationManagerResolver
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoders
+import org.springframework.security.oauth2.server.resource.authentication.JwtReactiveAuthenticationManager
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+class TrustedIssuerJwtAuthenticationManagerResolver(
+    val trustedIssuersConfig: F2TrustedIssuersConfig
+): ReactiveAuthenticationManagerResolver<String> {
+
+    private val authenticationManagers: MutableMap<String, Mono<ReactiveAuthenticationManager>> = ConcurrentHashMap()
+
+    override fun resolve(issuer: String): Mono<ReactiveAuthenticationManager> {
+        if (!issuer.startsWith(trustedIssuersConfig.issuerBaseUri)) return Mono.empty()
+        //TODO VERIFY the realm exists
+        return this.authenticationManagers.computeIfAbsent(issuer) {
+            buildAuthenticationManager(issuer).subscribeOn(Schedulers.boundedElastic())
+                .cache(
+                    /* ttlForValue = */ { Duration.ofMillis(Long.MAX_VALUE) },
+                    /* ttlForError = */ { Duration.ZERO },
+                    /* ttlForEmpty = */ { Duration.ZERO }
+                )
+        }
+    }
+
+    private fun buildAuthenticationManager(issuer: String) = Mono.fromCallable<ReactiveAuthenticationManager> {
+        JwtReactiveAuthenticationManager(
+            ReactiveJwtDecoders.fromIssuerLocation(issuer)
+        ).apply {
+            setJwtAuthenticationConverter(jwtAuthenticationConverter())
+        }
+    }
+
+    fun jwtAuthenticationConverter(): ReactiveJwtAuthenticationConverter {
+        return ReactiveJwtAuthenticationConverter().apply {
+            setJwtGrantedAuthoritiesConverter(::jwtAuthoritiesConverter)
+        }
+    }
+
+    fun jwtAuthoritiesConverter(jwt: Jwt): Flux<GrantedAuthority> {
+        val realmAccess = jwt.claims["realm_access"] as Map<String, List<String>>?
+        return realmAccess?.get("roles").orEmpty().map { role ->
+            SimpleGrantedAuthority("${WebSecurityConfig.ROLE_PREFIX}$role")
+        }.let { Flux.fromIterable(it) }
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.komune.f2.spring.boot.auth.config.WebSecurityConfig

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
 include(
 	"f2-spring:auth:f2-spring-boot-starter-auth",
 	"f2-spring:auth:f2-spring-boot-starter-auth-keycloak",
+	"f2-spring:auth:f2-spring-boot-starter-auth-tenant",
 )
 
 // TODO: Disable data need before removing it


### PR DESCRIPTION
dependencies and configuration files
The changes introduce a new module called f2-spring-boot-starter-auth-tenant containing Kotlin files for AuthenticationProvider, PermissionEvaluator, and ConfigurationConstants. The build.gradle.kts file is added with necessary dependencies and plugins for the module. This new module enhances the authentication functionality of the application by providing classes for handling security context, authentication, authorization, and configuration constants.

feat(auth): add TrustedIssuerJwtAuthenticationManagerResolver class for resolving authentication managers based on trusted issuers
feat(auth): add TrustedIssuerJwtAuthenticationManagerResolver class to dynamically resolve ReactiveAuthenticationManagers based on trusted issuers. This class allows for building and caching authentication managers for specific issuers, improving the flexibility and security of the authentication process. Additionally, a new import for WebSecurityConfig is added to the AutoConfiguration imports file, and the f2-spring-boot-starter-auth-tenant module is included in the settings.gradle.kts file for future development.