### PR TITLE
Add promote task

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@7c7698e378589bc31c719f2e6b943ac382216123
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,15 +4,17 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@7c7698e378589bc31c719f2e6b943ac382216123
     permissions:
       contents: read
       packages: write
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -4,11 +4,11 @@ on: [push]
 
 jobs:
   Sec:
-    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@7c7698e378589bc31c719f2e6b943ac382216123
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   Sec:
-    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@7c7698e378589bc31c719f2e6b943ac382216123
+    uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ lint: lint-libs
 build: build-libs
 test: test-libs
 package: package-libs
+promote: promote-libs
 
 # Old task
 libs: package-kotlin
@@ -20,7 +21,11 @@ test-libs:
 	./gradlew test
 
 package-libs: build-libs
-	./gradlew publish
+	PKG_MAVEN_REPO=github ./gradlew publish
+
+promote-libs: build-libs
+	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+
 
 version:
 	@VERSION=$$(cat VERSION); \

--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,17 @@ lint-libs:
 	./gradlew detekt
 
 build-libs:
-	./gradlew build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-libs:
 	./gradlew test
 
-publish-libs: build-libs
-	PKG_MAVEN_REPO=github ./gradlew publish
+publish-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
 
-promote-libs: build-libs
-	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+promote-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
 
 .PHONY: version
 version:
-	echo "$$VERSION"
+	@echo "$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint-libs:
 	./gradlew detekt
 
 build-libs:
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal --refresh-dependencies -x test
 
 test-libs:
 	./gradlew test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-
-.PHONY: version
+VERSION = $(shell cat VERSION)
 
 lint: lint-libs
 build: build-libs
 test: test-libs
-package: package-libs
+publish: publish-libs
 promote: promote-libs
 
 # Old task
@@ -20,13 +19,12 @@ build-libs:
 test-libs:
 	./gradlew test
 
-package-libs: build-libs
+publish-libs: build-libs
 	PKG_MAVEN_REPO=github ./gradlew publish
 
 promote-libs: build-libs
 	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
 
-
+.PHONY: version
 version:
-	@VERSION=$$(cat VERSION); \
 	echo "$$VERSION"


### PR DESCRIPTION
…ERNAME and PKG_GITHUB_TOKEN for consistency

chore(sec.yml): update secrets naming convention to use PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN for consistency chore(Makefile): add 'promote' target to promote libraries to different repositories The changes were made to ensure consistency in the naming convention of secrets across different workflows. Additionally, a new 'promote' target was added to the Makefile to allow promoting libraries to different repositories based on the PKG_MAVEN_REPO environment variable.