### PR TITLE
chore(dev.yml): update dev workflow to include support for tags and additional configurations

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,13 +7,18 @@ on:
     branches:
       - main
       - 'release/*'
+    tags:
+      - '*'
 
 jobs:
-  dev:
+  libs:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write
+    with:
+      make-file: 'Makefile'
+      on-tag: 'promote'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
@@ -30,9 +35,14 @@ jobs:
       pages: write
       id-token: write
     with:
+      on-tag: 'publish_promote'
       with-chromatic: false
       storybook-dir: storybook
       storybook-static-dir: storybook-static
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}


### PR DESCRIPTION
The dev workflow now includes support for triggering on tags in addition to branches. The 'libs' job now includes configurations for 'make-file' and 'on-tag' to specify the Makefile and trigger the job on the 'promote' tag. The 'publish' job also includes configurations for 'on-tag' to trigger on 'publish_promote' tag and additional secrets for Docker publishing and promotion. These changes enhance the flexibility and functionality of the dev workflow.