### PR TITLE
build(f2-client-ktor): remove unnecessary jsMainApi dependency in build.gradle.kts

### DIFF
--- a/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
     commonMainApi("io.ktor:ktor-client-content-negotiation:${Versions.Kotlin.ktor}")
     commonMainApi("io.ktor:ktor-serialization-kotlinx-json:${Versions.Kotlin.ktor}")
 
-//    jsMainApi("io.ktor:ktor-client-json-js:${Versions.Kotlin.ktor}")
-
     jvmMainImplementation("io.ktor:ktor-client-cio:${Versions.Kotlin.ktor}")
     jvmMainImplementation("io.ktor:ktor-client-jackson:${Versions.Kotlin.ktor}")
 

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
@@ -2,4 +2,8 @@ package f2.client.ktor.http
 
 expect fun httpClientBuilder(): HttpClientBuilder
 
-expect class HttpClientBuilder
+expect class HttpClientBuilder {
+
+    fun build(urlBase: String): HttpF2Client
+
+}

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jsMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jsMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
@@ -1,6 +1,5 @@
 package f2.client.ktor.http
 
-import f2.client.F2Client
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.js.Js
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -15,8 +14,9 @@ import kotlinx.serialization.json.Json
 actual class HttpClientBuilder(
 	private val json: Json = F2DefaultJson
 ) {
-	fun build(urlBase: String): Promise<HttpF2Client> = GlobalScope.promise {
-		HttpF2Client(
+
+	actual fun build(urlBase: String): HttpF2Client {
+		return HttpF2Client(
 			urlBase = urlBase,
 			httpClient = httpClient(json)
 		)
@@ -29,7 +29,6 @@ actual class HttpClientBuilder(
 			}
 		}
 	}
-
 }
 
 actual fun httpClientBuilder() = HttpClientBuilder()

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
@@ -15,9 +15,8 @@ actual class HttpClientBuilder(
 	private val json: Json? = F2DefaultJson,
 	private val config: F2ClientConfigLambda? = null
 ) {
-	fun build(
+	actual fun build(
 		urlBase: String
-
 	): HttpF2Client {
 		val httpCLient = httpClient(json ?: F2DefaultJson, config)
 		return HttpF2Client(
@@ -25,6 +24,7 @@ actual class HttpClientBuilder(
 			urlBase
 		)
 	}
+
 	private fun httpClient(json: Json = F2DefaultJson, config: F2ClientConfigLambda?): HttpClient {
 		return HttpClient(CIO) {
 			install(ContentNegotiation) {

--- a/f2-client/f2-client-ktor/src/jsMain/kotlin/f2/client/ktor/get.kt
+++ b/f2-client/f2-client-ktor/src/jsMain/kotlin/f2/client/ktor/get.kt
@@ -6,13 +6,25 @@ import f2.client.ktor.http.httpClientBuilder
 import f2.client.ktor.rsocket.RSocketF2ClientBuilder
 import f2.client.ktor.rsocket.rSocketF2ClientBuilder
 import kotlin.js.Promise
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+fun F2ClientBuilder.getHttp(
+	url: String,
+): F2Client {
+	return when {
+		url.startsWith("http:") -> httpClientBuilder().build(url)
+		url.startsWith("https:") -> httpClientBuilder().build(url)
+		else -> throw IllegalArgumentException("Invalid Url[${url}] must start by one of http:, https:, tcp: ws: wss:")
+	}
+}
 
 fun F2ClientBuilder.get(
 	url: String,
 ): Promise<F2Client> {
 	return when {
-		url.startsWith("http:") -> httpClientBuilder().build(url)
-		url.startsWith("https:") -> httpClientBuilder().build(url)
+		url.startsWith("http:") -> GlobalScope.promise { httpClientBuilder().build(url) }
+		url.startsWith("https:") -> GlobalScope.promise { httpClientBuilder().build(url) }
 		url.startsWith("tcp:") -> rSocketF2ClientBuilder().build(url, false)
 		url.startsWith("ws:") -> rSocketF2ClientBuilder().build(url, false)
 		url.startsWith("wss:") -> rSocketF2ClientBuilder().build(url, false)
@@ -28,8 +40,8 @@ fun F2ClientBuilder.get(
 ): Promise<F2Client> {
 	val pathA = path?.let { "/$path" } ?: ""
 	return when (protocol) {
-		is HTTP -> HttpClientBuilder().build("http://$host:$port$pathA")
-		is HTTPS -> HttpClientBuilder().build("https://$host:$port$pathA")
+		is HTTP -> GlobalScope.promise { HttpClientBuilder().build("http://$host:$port$pathA") }
+		is HTTPS -> GlobalScope.promise {  HttpClientBuilder().build("https://$host:$port$pathA") }
 		is TCP -> RSocketF2ClientBuilder().build("tcp://$host:$port$pathA", false)
 		is WS -> RSocketF2ClientBuilder().build("ws://$host:$port$pathA", false)
 		is WSS -> RSocketF2ClientBuilder().build("wss://$host:$port$pathA", true)

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.Scope
-import io.komune.gradle.dependencies.add
 
 plugins {
     id("io.komune.fixers.gradle.kotlin.jvm")


### PR DESCRIPTION
refactor(f2-client-ktor): update HttpClientBuilder in commonMain and jsMain to match expected interface refactor(f2-client-ktor): update HttpClientBuilder in jvmMain to match expected interface refactor(f2-client-ktor): update getHttp function in get.kt to return F2Client instead of Promise The changes were made to clean up the build.gradle.kts file by removing an unnecessary dependency. Additionally, the HttpClientBuilder class in commonMain and jsMain directories was updated to match the expected interface. The HttpClientBuilder class in jvmMain was also updated to match the expected interface. Lastly, the getHttp function in get.kt was modified to return F2Client directly instead of a Promise.