### PR TITLE
build(Makefile): enable parallel execution for publishing libraries to improve build performance

### DIFF
--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/model/AuthRealm.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/model/AuthRealm.kt
@@ -13,7 +13,7 @@ sealed class AuthRealm(
 )
 
 @JsExport
-class AuthRealmPassword(
+data class AuthRealmPassword(
     override val serverUrl: String,
     override val realmId: RealmId,
     override val redirectUrl: String,
@@ -23,7 +23,7 @@ class AuthRealmPassword(
 ): AuthRealm(serverUrl, realmId, clientId, redirectUrl)
 
 @JsExport
-class AuthRealmClientSecret(
+data class AuthRealmClientSecret(
     override val serverUrl: String,
     override val realmId: RealmId,
     override val clientId: String,

--- a/libs.mk
+++ b/libs.mk
@@ -12,7 +12,7 @@ test:
 	./gradlew test
 
 publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true
 
 promote:
 	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish


### PR DESCRIPTION
By adding the flag -Dorg.gradle.parallel=true to the publish-libs target, the build process will now execute tasks in parallel, which can significantly improve the performance of publishing libraries. This change aims to optimize the build process and reduce the overall time taken for publishing libraries.