### PR TITLE
refactor(HttpClientBuilder.kt): make json parameter nullable in httpClient method

### DIFF
--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
@@ -25,10 +25,12 @@ actual class HttpClientBuilder(
 		)
 	}
 
-	private fun httpClient(json: Json = F2DefaultJson, config: F2ClientConfigLambda?): HttpClient {
+	private fun httpClient(json: Json? = F2DefaultJson, config: F2ClientConfigLambda?): HttpClient {
 		return HttpClient(CIO) {
-			install(ContentNegotiation) {
-				json(json)
+			json?.let {
+				install(ContentNegotiation) {
+					json(json)
+				}
 			}
 			config?.let { config(this) }
 		}


### PR DESCRIPTION
The json parameter in the httpClient method is now nullable to allow for more flexibility when calling the method. This change ensures that the method can be called without specifying a json parameter, making it more versatile in different scenarios.