### PR TITLE
fix(Dependencies.kt): downgrade rsocket version from 0.16.0 to 0.15.4 to resolve compatibility issues

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -46,7 +46,7 @@ object Versions {
 	const val cucumber = FixersVersions.Test.cucumber
 //	const val springdoc = "1.8.0"
 	const val springdoc = "1.6.11"
-	const val rsocket = "0.16.0"
+	const val rsocket = "0.15.4"
 }
 
 object Dependencies {


### PR DESCRIPTION
The rsocket version has been downgraded from 0.16.0 to 0.15.4 to address compatibility issues with other dependencies in the project.