### PR TITLE
fix(Dependencies.kt): update rsocket version from 0.15.4 to 0.16.0 for compatibility and potential bug fixes

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -46,7 +46,7 @@ object Versions {
 	const val cucumber = FixersVersions.Test.cucumber
 //	const val springdoc = "1.8.0"
 	const val springdoc = "1.6.11"
-	const val rsocket = "0.15.4"
+	const val rsocket = "0.16.0"
 }
 
 object Dependencies {


### PR DESCRIPTION
The rsocket library version has been updated from 0.15.4 to 0.16.0 to ensure compatibility with other dependencies and to potentially benefit from bug fixes or new features introduced in the newer version.