### PR TITLE
Refactor and Enhance Domain Model Handling and JSON Configuration for HTTP and RSocket Clients

### DIFF
--- a/f2-client/f2-client-domain/build.gradle.kts
+++ b/f2-client/f2-client-domain/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("io.komune.fixers.gradle.kotlin.mpp")
+    id("io.komune.fixers.gradle.publish")
+    //id("io.komune.fixers.gradle.npm")
+    kotlin("plugin.serialization")
+}
+
+dependencies {
+
+}

--- a/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/AuthRealm.kt
+++ b/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/AuthRealm.kt
@@ -1,4 +1,4 @@
-package f2.client.ktor.http.plugin.model
+package f2.client.domain
 
 import kotlin.js.JsExport
 
@@ -27,7 +27,7 @@ data class AuthRealmClientSecret(
     override val serverUrl: String,
     override val realmId: RealmId,
     override val clientId: String,
-    override val redirectUrl: String?,
+    override val redirectUrl: String? = null,
     val clientSecret: String,
     val isPublic: Boolean = false,
 ): AuthRealm(serverUrl, realmId, clientId, redirectUrl)

--- a/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/TokenInfo.kt
+++ b/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/TokenInfo.kt
@@ -1,4 +1,4 @@
-package f2.client.ktor.http.plugin.model
+package f2.client.domain
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
     commonMainApi(project(":f2-client:f2-client-core"))
+    commonMainApi(project(":f2-client:f2-client-domain"))
     commonMainApi(project(":f2-dsl:f2-dsl-cqrs"))
     commonMainApi(project(":f2-client:f2-client-ktor:f2-client-ktor-common"))
 

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/F2Auth.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/F2Auth.kt
@@ -1,10 +1,10 @@
 package f2.client.ktor.http.plugin
 
 import f2.client.ktor.common.F2DefaultJson
-import f2.client.ktor.http.plugin.model.AuthRealm
-import f2.client.ktor.http.plugin.model.AuthRealmClientSecret
-import f2.client.ktor.http.plugin.model.AuthRealmPassword
-import f2.client.ktor.http.plugin.model.TokenInfo
+import f2.client.domain.AuthRealm
+import f2.client.domain.AuthRealmClientSecret
+import f2.client.domain.AuthRealmPassword
+import f2.client.domain.TokenInfo
 import f2.dsl.cqrs.error.F2Error
 import f2.dsl.cqrs.error.asException
 import io.ktor.client.HttpClient

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientTest.kt
@@ -2,12 +2,11 @@ package f2.client.ktor.http
 
 import f2.client.ktor.http.model.F2FilePart
 import f2.client.ktor.http.plugin.F2Auth
-import f2.client.ktor.http.plugin.model.AuthRealmClientSecret
+import f2.client.domain.AuthRealmClientSecret
 import f2.client.ktor.http.server.ServerClient
 import f2.client.ktor.http.server.command.ServerConsumeCommand
 import f2.client.ktor.http.server.command.ServerUploadCommand
 import f2.client.ktor.http.server.command.ServerUploadCommandBody
-import f2.spring.KSerializationMapper.Companion.defaultJson
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/TokenInfoSerializationTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/TokenInfoSerializationTest.kt
@@ -1,7 +1,7 @@
 package f2.client.ktor.http
 
 import f2.client.ktor.common.F2DefaultJson
-import f2.client.ktor.http.plugin.model.TokenInfo
+import f2.client.domain.TokenInfo
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 

--- a/f2-spring/function/f2-spring-boot-starter-function-http/src/test/kotlin/f2/spring/http/Test.kt
+++ b/f2-spring/function/f2-spring-boot-starter-function-http/src/test/kotlin/f2/spring/http/Test.kt
@@ -1,0 +1,4 @@
+package f2.spring.http
+
+class Test {
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ include(
 
 include(
 	"f2-client:f2-client-core",
+	"f2-client:f2-client-domain",
 	"f2-client:f2-client-ktor",
 	"f2-client:f2-client-ktor:f2-client-ktor-common",
 	"f2-client:f2-client-ktor:f2-client-ktor-http",


### PR DESCRIPTION
Introduced a new f2-client-domain module to encapsulate domain models and improve modularity and separation of concerns across modules.
Centralized default JSON configuration and removed redundant parameters to streamline HTTP and RSocket client builders, reducing code duplication and improving consistency.