### PR TITLE
feat(HttpF2Client): introduce `urlBase` for cross-platform consistency

### DIFF
--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
@@ -5,4 +5,5 @@ import io.ktor.client.HttpClient
 
 expect open class HttpF2Client : F2Client {
     val httpClient: HttpClient
+    val urlBase: String
 }

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jsMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jsMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
@@ -42,7 +42,7 @@ import kotlinx.serialization.serializer
 @JsExport
 actual open class HttpF2Client(
 	actual val httpClient: HttpClient,
-	val urlBase: String,
+	actual val urlBase: String,
 	val json: Json = F2DefaultJson
 ) : F2Client {
 

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
@@ -43,7 +43,7 @@ import kotlinx.serialization.serializer
 
 actual open class HttpF2Client(
 	actual val httpClient: HttpClient,
-	val urlBase: String,
+	actual val urlBase: String,
 	val json: Json = F2DefaultJson
 ) : F2Client {
 


### PR DESCRIPTION
Added `urlBase` property to `HttpF2Client` in `commonMain`, now consistently implemented across `jsMain` and `jvmMain`. Enhances HTTP client configurability with a unified base URL for endpoint construction.

