### PR TITLE
refactor: switch from CIO to Java HTTP client engine

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -64,7 +64,7 @@ object Dependencies {
 
 			fun client(commonMainApi: Scope, jvmScope: Scope, jsScope: Scope) {
 				jvmScope.add(
-					"io.ktor:ktor-client-cio:${Versions.Kotlin.ktor}"
+					"io.ktor:ktor-client-java:${Versions.Kotlin.ktor}"
 				)
 				jsScope.add(
 					"io.ktor:ktor-client-js:${Versions.Kotlin.ktor}"

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     commonMainApi("io.ktor:ktor-client-core:${Versions.Kotlin.ktor}")
     commonMainApi("io.ktor:ktor-client-auth:${Versions.Kotlin.ktor}")
 
+
+
     Dependencies.Mpp.Ktor.client(::commonMainApi, ::jvmMainApi, ::jsMainApi)
 
     Dependencies.Mpp.uuid(::commonMainApi)

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilder.kt
@@ -3,8 +3,8 @@ package f2.client.ktor.http
 import f2.client.ktor.common.F2ClientConfigLambda
 import f2.client.ktor.common.applyConfig
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.engine.cio.CIOEngineConfig
+import io.ktor.client.engine.java.Java
+import io.ktor.client.engine.java.JavaHttpConfig
 
 /**
  * Builder class for creating instances of [HttpF2Client].
@@ -13,7 +13,7 @@ import io.ktor.client.engine.cio.CIOEngineConfig
  * @param config Additional configuration for the HTTP client. Defaults to an empty lambda.
  */
 actual class HttpClientBuilder(
-	private val config: F2ClientConfigLambda<CIOEngineConfig>? = {}
+	private val config: F2ClientConfigLambda<JavaHttpConfig>? = {}
 ) {
 	/**
 	 * Builds an [HttpF2Client] with the specified base URL.
@@ -35,7 +35,7 @@ actual class HttpClientBuilder(
 	 * @return An instance of [HttpClient].
 	 */
 	private fun httpClient(): HttpClient {
-		return HttpClient(CIO) {
+		return HttpClient(Java) {
 			applyConfig(config)
 		}
 	}

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilderExtension.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmMain/kotlin/f2/client/ktor/http/HttpClientBuilderExtension.kt
@@ -2,8 +2,7 @@
 package f2.client.ktor.http
 
 import f2.client.ktor.common.F2ClientConfigLambda
-import io.ktor.client.engine.cio.CIOEngineConfig
-
+import io.ktor.client.engine.java.JavaHttpConfig
 
 
 /**
@@ -31,7 +30,7 @@ actual fun httpClientBuilderGenerics(
  * @return An instance of [HttpClientBuilder] with the specified configuration.
  */
 fun httpClientBuilder(
-    config: F2ClientConfigLambda<CIOEngineConfig>? = {  }
+    config: F2ClientConfigLambda<JavaHttpConfig>? = {  }
 ) = HttpClientBuilder(config)
 
 /**
@@ -41,5 +40,5 @@ fun httpClientBuilder(
  * @return An instance of [HttpClientBuilder] with the specified configuration.
  */
 fun HttpClientBuilder.Companion.builder(
-    config: F2ClientConfigLambda<CIOEngineConfig>? = { }
+    config: F2ClientConfigLambda<JavaHttpConfig>? = { }
 ) = HttpClientBuilder(config)

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientTest.kt
@@ -8,7 +8,7 @@ import f2.client.ktor.http.server.command.ServerConsumeCommand
 import f2.client.ktor.http.server.command.ServerUploadCommand
 import f2.client.ktor.http.server.command.ServerUploadCommandBody
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.java.Java
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
@@ -107,7 +107,7 @@ class HttpF2ClientTest {
 	fun test(): Unit = runTest {
 		val client = ServerClient(
 			client = HttpF2Client(
-				httpClient = HttpClient(CIO) {
+				httpClient = HttpClient(Java) {
 					install(ContentNegotiation) {
 						json(Json {
 							ignoreUnknownKeys = true

--- a/f2-client/f2-client-ktor/f2-client-ktor-rsocket/src/jvmMain/kotlin/f2/client/ktor/rsocket/builder/RSocketF2ClientBuilder.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-rsocket/src/jvmMain/kotlin/f2/client/ktor/rsocket/builder/RSocketF2ClientBuilder.kt
@@ -5,8 +5,8 @@ import f2.client.ktor.common.applyConfig
 import f2.client.ktor.rsocket.RSocketClient
 import f2.client.ktor.rsocket.RSocketF2Client
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.engine.cio.CIOEngineConfig
+import io.ktor.client.engine.java.Java
+import io.ktor.client.engine.java.JavaHttpConfig
 import io.rsocket.kotlin.RSocket
 import io.rsocket.kotlin.ktor.client.rSocket
 
@@ -16,7 +16,7 @@ import io.rsocket.kotlin.ktor.client.rSocket
  * @param config Additional configuration for the RSocket client. Defaults to null.
  */
 actual class RSocketF2ClientBuilder(
-	private val config: F2ClientConfigLambda<CIOEngineConfig>? = null,
+	private val config: F2ClientConfigLambda<JavaHttpConfig>? = null,
 ) {
 
 	/**
@@ -41,7 +41,7 @@ actual class RSocketF2ClientBuilder(
 	 *
 	 * @return An instance of [HttpClient].
 	 */
-	private fun build(): HttpClient = HttpClient(CIO) {
+	private fun build(): HttpClient = HttpClient(Java) {
 		applyRSocket()
 		applyConfig(config)
 	}
@@ -90,7 +90,7 @@ actual fun rSocketF2ClientBuilderGenerics(
  * @return An instance of [RSocketClientBuilder] with the specified configuration.
  */
 fun rSocketClientBuilder(
-	config: F2ClientConfigLambda<CIOEngineConfig>? = {  }
+	config: F2ClientConfigLambda<JavaHttpConfig>? = {  }
 ) = RSocketF2ClientBuilder(config)
 
 /**
@@ -100,6 +100,6 @@ fun rSocketClientBuilder(
  * @return An instance of [RSocketClientBuilder] with the specified configuration.
  */
 fun RSocketF2ClientBuilder.Companion.builder(
-	config: F2ClientConfigLambda<CIOEngineConfig>? = { }
+	config: F2ClientConfigLambda<JavaHttpConfig>? = { }
 ) = RSocketF2ClientBuilder(config)
 

--- a/f2-client/f2-client-ktor/src/jvmMain/kotlin/f2/client/ktor/get.kt
+++ b/f2-client/f2-client-ktor/src/jvmMain/kotlin/f2/client/ktor/get.kt
@@ -4,11 +4,11 @@ import f2.client.F2Client
 import f2.client.ktor.common.F2ClientConfigLambda
 import f2.client.ktor.http.httpClientBuilder
 import f2.client.ktor.rsocket.builder.rSocketF2ClientBuilderDefault
-import io.ktor.client.engine.cio.CIOEngineConfig
+import io.ktor.client.engine.java.JavaHttpConfig
 
 suspend fun F2ClientBuilder.get(
     urlBase: String,
-    config: F2ClientConfigLambda<CIOEngineConfig>? = null
+    config: F2ClientConfigLambda<JavaHttpConfig>? = null
 ): F2Client {
 	return when {
 		urlBase.startsWith("http:") -> httpClientBuilder(config).build(urlBase)


### PR DESCRIPTION
Switching from the CIO to the Java HTTP client engine improves compatibility and performance on JVM platforms. The Java engine provides better integration with the Java ecosystem and can leverage native Java features for enhanced performance. This change also simplifies the configuration by using JavaHttpConfig instead of CIOEngineConfig, aligning with the project's goal to optimize networking capabilities.