### PR TITLE
Introduce and Enhance Batch and Chunk Operators for Flow

### DIFF
--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/groupBy.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/groupBy.kt
@@ -32,4 +32,3 @@ fun <T, K> Flow<T>.groupBy(keySelector: (T) -> K): Flow<Pair<K, Flow<T>>> = chan
         groups.values.forEach { it.close() }
     }
 }
-


### PR DESCRIPTION
Add chunkFlow and batch operators to process Flow elements in configurable chunks and with optional concurrency.