### PR TITLE
Introduce batchFlow and simplify chunkFlow for consistent Flow processing

### DIFF
--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/batch.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/batch.kt
@@ -19,6 +19,19 @@ fun <T, R> Flow<T>.batch(
 ): Flow<R> = chunk(batch.size, fnc).flattenConcurrently(batch.concurrency)
 
 /**
+ * Extension function to batch elements of a Flow into lists of a specified size and
+ * apply a transformation function to each batch.
+ *
+ * @param batch An instance of [Batch] containing the size of each batch and the concurrency level.
+ * @param fnc A suspend function to apply to each batch of elements.
+ * @return A Flow emitting transformed elements.
+ */
+fun <T, R> Flow<T>.batchFlow(
+    batch: Batch,
+    fnc: suspend (t: List<T>) -> Flow<R>
+): Flow<R> = chunkFlow(batch.size, fnc).flattenConcurrently(batch.concurrency)
+
+/**
  * Default concurrency level for batching.
  */
 val BATCH_DEFAULT_CONCURRENCY: Int = DEFAULT_CONCURRENCY

--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/chunk.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/chunk.kt
@@ -43,18 +43,18 @@ fun <T, R> Flow<T>.chunk(
  */
 fun <T, R> Flow<T>.chunkFlow(
     size: Int = CHUNK_DEFAULT_SIZE,
-    fnc: suspend (t: Flow<T>) -> Flow<R>
-): Flow<R> = flow {
+    fnc: suspend (t: List<T>) -> Flow<R>
+): Flow<Flow<R>> = flow {
     val buffer = mutableListOf<T>()
     collect { value ->
         buffer.add(value)
         if (buffer.size == size) {
-            fnc(buffer.asFlow()).collect { emit(it) }
+            fnc(buffer).let { emit(it) }
             buffer.clear()
         }
     }
     if (buffer.isNotEmpty()) {
-        fnc(buffer.asFlow()).collect { emit(it) }
+        fnc(buffer).let { emit(it) }
     }
 }
 


### PR DESCRIPTION
Add a new batchFlow function to process Flow elements in batched lists with a transformation function returning a Flow.
Refactor chunkFlow to accept a list-based transformation function, ensuring a more consistent API and simpler processing logic.