### PR TITLE
Add default issuerBaseUri and refine WebSecurityConfig ordering

### DIFF
--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfig.kt
@@ -4,5 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "f2.tenant")
 data class F2TrustedIssuersConfig (
-    val issuerBaseUri: String
+    val issuerBaseUri: String = ""
 )

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.security.authorization.AuthorizationDecision
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.core.Authentication
@@ -23,11 +24,11 @@ import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 import reactor.core.publisher.Mono
 
-@Suppress("UnnecessaryAbstractClass")
+@Order(value = 100)
 @Configuration
 @ConditionalOnMissingBean(WebSecurityConfig::class)
 @EnableConfigurationProperties(F2TrustedIssuersConfig::class)
-abstract class WebSecurityConfig {
+class WebSecurityConfig {
 
     companion object {
         const val SPRING_SECURITY_FILTER_CHAIN = "springSecurityFilterChain"


### PR DESCRIPTION
Provide a default empty issuerBaseUri to prevent null pointer exceptions in F2TrustedIssuersConfig.
Remove unnecessary abstract modifier and assign @Order to WebSecurityConfig to ensure proper security configuration sequence.