### PR TITLE
Rename publish target to stage and update Sonatype snapshot repository URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ test:
 	@make -f libs.mk test
 	@make -f docs.mk test
 
-publish:
-	@make -f libs.mk publish
-	@make -f docs.mk publish
+stage:
+	@make -f libs.mk stage
+	@make -f docs.mk stage
 
 promote:
 	@make -f libs.mk promote

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,8 +1,8 @@
-import io.komune.gradle.dependencies.FixersDependencies
-import io.komune.gradle.dependencies.FixersPluginVersions
-import io.komune.gradle.dependencies.FixersVersions
-import io.komune.gradle.dependencies.Scope
-import io.komune.gradle.dependencies.add
+import io.komune.fixers.gradle.dependencies.FixersDependencies
+import io.komune.fixers.gradle.dependencies.FixersPluginVersions
+import io.komune.fixers.gradle.dependencies.FixersVersions
+import io.komune.fixers.gradle.dependencies.Scope
+import io.komune.fixers.gradle.dependencies.add
 import java.net.URI
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -204,7 +204,7 @@ object Modules {
 
 fun RepositoryHandler.defaultRepo() {
 	mavenCentral()
-	maven { url = URI("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
 	maven { url = URI("https://repo.spring.io/milestone") }
 	mavenLocal()
 }

--- a/make_libs.mk
+++ b/make_libs.mk
@@ -11,11 +11,11 @@ build:
 test:
 	./gradlew test
 
-publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true
+stage:
+	VERSION=$(VERSION) ./gradlew stage
 
 promote:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+	VERSION=$(VERSION) ./gradlew promote
 
 version:
 	@echo "$(VERSION)"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
-		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 		mavenLocal()
 	}
 }


### PR DESCRIPTION
Renamed the publish target to stage in Makefile and related files for improved clarity.
Updated Sonatype snapshot repository URL in build files to ensure accurate dependency resolution.