### PR TITLE
chore(dev.yml): update on-tag value from 'publish_promote' to 'stage_promote' for clarity

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,7 +36,7 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'publish_promote'
+      on-tag: 'stage_promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
       storybook-dir: storybook


### PR DESCRIPTION
The change to the on-tag value enhances clarity in the workflow by better reflecting the intended action. Using 'stage_promote' instead of 'publish_promote' aligns the tag with the actual promotion stage in the deployment process.