### PR TITLE
chore(build): conditionally include mavenLocal repository based on MAVEN_LOCAL_USE environment variable

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 repositories {
 	mavenCentral()
 	maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
+	if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+		mavenLocal()
+	}
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -205,6 +205,7 @@ object Modules {
 fun RepositoryHandler.defaultRepo() {
 	mavenCentral()
 	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
-	maven { url = URI("https://repo.spring.io/milestone") }
-	mavenLocal()
+	if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+		mavenLocal()
+	}
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,9 @@ pluginManagement {
 		gradlePluginPortal()
 		mavenCentral()
 		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-		mavenLocal()
+		if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+			mavenLocal()
+		}
 	}
 }
 


### PR DESCRIPTION
The build configuration now conditionally includes the mavenLocal repository if the MAVEN_LOCAL_USE environment variable is set to "true". This change allows for more flexible build setups, enabling developers to use local Maven repositories when needed without hardcoding it into the build script.