### PR TITLE
chore(ci): update GitHub Actions workflow to improve tag handling and add base directory for Storybook

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,11 +34,13 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'stage_promote'
+      on-tag: 'stage promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
+      base-dir: "storybook"
       storybook-dir: storybook
       storybook-static-dir: storybook-static
+
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
The tag for the deployment is changed from 'stage_promote' to 'stage promote' for better readability. Additionally, a base directory for Storybook is specified to ensure that the workflow correctly references the Storybook files, improving the overall structure and clarity of the CI process.