### PR TITLE
fix(security): add ConditionalOnBean annotation to dummyAuthenticationProvider for better bean management

### DIFF
--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
@@ -6,6 +6,7 @@ import jakarta.annotation.security.RolesAllowed
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -52,6 +53,7 @@ class WebSecurityConfig {
 
     @Bean(SPRING_SECURITY_FILTER_CHAIN)
     @ConditionalOnExpression(NO_AUTHENTICATION_REQUIRED_EXPRESSION)
+    @ConditionalOnBean(ServerHttpSecurity::class)
     fun dummyAuthenticationProvider(http: ServerHttpSecurity): SecurityWebFilterChain {
         logger.trace("Executing dummyAuthenticationProvider (permitAll)")
 


### PR DESCRIPTION
The addition of the @ConditionalOnBean annotation ensures that the dummyAuthenticationProvider bean is only created if the ServerHttpSecurity bean is present. This improves the application's configuration by preventing potential issues related to missing dependencies and enhances the overall robustness of the security setup.