### PR TITLE
refactor(mapToEnvelope)!: remove random-id default, force explicit choice

### DIFF
--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
@@ -11,21 +11,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
-// =====================================================================================
-// Required-id variants — the caller decides what the envelope id is.
-//
-// The previous default `{ Uuid.random().toString() }` silently severed any caller-side
-// correlation between input commands and resulting outcomes (the envelope id flows
-// through s2's PersistOutcome.msgId). Callers that need fire-and-forget random ids
-// must now opt in explicitly via `mapToEnvelopeWithRandomId(...)`.
-// =====================================================================================
-
-/**
- * Maps each input through this [F2Function] and wraps the result in an [Envelope]
- * whose id is derived from the input via [id]. Use this when the caller needs to
- * correlate outputs back to inputs (any pipeline that surfaces per-msgId failure
- * routing).
- */
 inline fun <T, reified R> F2Function<T, R>.mapToEnvelope(
     crossinline id: (T) -> String,
 ): F2Function<T, Envelope<R>> = F2Function { inputs: Flow<T> ->
@@ -39,9 +24,6 @@ inline fun <T, reified R> F2Function<T, R>.mapToEnvelope(
     }
 }
 
-/**
- * Wraps each element of this [Flow] in an [Envelope] whose id is derived via [id].
- */
 inline fun <reified T> Flow<T>.mapToEnvelope(
     crossinline id: (T) -> String,
 ): Flow<Envelope<T>> = map { input ->
@@ -50,10 +32,6 @@ inline fun <reified T> Flow<T>.mapToEnvelope(
     )
 }
 
-/**
- * Wraps each element of this [Flow] in an [Envelope] with the given [type], whose id
- * is derived via [id].
- */
 fun <T> Flow<T>.mapToEnvelope(
     type: String,
     id: (T) -> String,
@@ -63,11 +41,6 @@ fun <T> Flow<T>.mapToEnvelope(
         type = type,
     )
 }
-
-// =====================================================================================
-// Explicit random-id opt-in variants — for fire-and-forget cases (output wrappings,
-// anonymous transforms) where caller-side correlation is not needed.
-// =====================================================================================
 
 @OptIn(ExperimentalUuidApi::class)
 inline fun <T, reified R> F2Function<T, R>.mapToEnvelopeWithRandomId(): F2Function<T, Envelope<R>> =
@@ -81,10 +54,6 @@ inline fun <reified T> Flow<T>.mapToEnvelopeWithRandomId(): Flow<Envelope<T>> =
 fun <T> Flow<T>.mapToEnvelopeWithRandomId(
     type: String,
 ): Flow<Envelope<T>> = mapToEnvelope(type) { Uuid.random().toString() }
-
-// =====================================================================================
-// Envelope-preserving transformations — unchanged.
-// =====================================================================================
 
 suspend inline fun <T, reified R> Envelope<T>.mapEnvelope(
     crossinline transform: suspend (value: T) -> R,

--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
@@ -32,9 +32,9 @@ inline fun <reified T> Flow<T>.mapToEnvelope(
     )
 }
 
-fun <T> Flow<T>.mapToEnvelope(
+inline fun <T> Flow<T>.mapToEnvelope(
     type: String,
-    id: (T) -> String,
+    crossinline id: (T) -> String,
 ): Flow<Envelope<T>> = map { input ->
     input.asEnvelopeWithType(
         id = id(input),
@@ -51,7 +51,7 @@ inline fun <reified T> Flow<T>.mapToEnvelopeWithRandomId(): Flow<Envelope<T>> =
     mapToEnvelope { Uuid.random().toString() }
 
 @OptIn(ExperimentalUuidApi::class)
-fun <T> Flow<T>.mapToEnvelopeWithRandomId(
+inline fun <T> Flow<T>.mapToEnvelopeWithRandomId(
     type: String,
 ): Flow<Envelope<T>> = mapToEnvelope(type) { Uuid.random().toString() }
 

--- a/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
+++ b/f2-dsl/f2-dsl-function/src/commonMain/kotlin/f2/dsl/fnc/operators/mapToEnvelope.kt
@@ -11,15 +11,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
+// =====================================================================================
+// Required-id variants — the caller decides what the envelope id is.
+//
+// The previous default `{ Uuid.random().toString() }` silently severed any caller-side
+// correlation between input commands and resulting outcomes (the envelope id flows
+// through s2's PersistOutcome.msgId). Callers that need fire-and-forget random ids
+// must now opt in explicitly via `mapToEnvelopeWithRandomId(...)`.
+// =====================================================================================
+
 /**
- * Extension function to map a Flow of inputs to a Flow of Envelopes containing the results.
- *
- * @param id A function to generate an ID for each input. Defaults to a random UUID.
- * @return A Flow emitting Envelopes containing the results.
+ * Maps each input through this [F2Function] and wraps the result in an [Envelope]
+ * whose id is derived from the input via [id]. Use this when the caller needs to
+ * correlate outputs back to inputs (any pipeline that surfaces per-msgId failure
+ * routing).
  */
-@OptIn(ExperimentalUuidApi::class)
 inline fun <T, reified R> F2Function<T, R>.mapToEnvelope(
-    crossinline id: (T) -> String = { Uuid.random().toString() },
+    crossinline id: (T) -> String,
 ): F2Function<T, Envelope<R>> = F2Function { inputs: Flow<T> ->
     inputs.map { input ->
         val resultFlow = this.invoke(flowOf(input))
@@ -32,14 +40,10 @@ inline fun <T, reified R> F2Function<T, R>.mapToEnvelope(
 }
 
 /**
- * Extension function to map a Flow of inputs to a Flow of Envelopes containing the inputs.
- *
- * @param id A function to generate an ID for each input. Defaults to a random UUID.
- * @return A Flow emitting Envelopes containing the inputs.
+ * Wraps each element of this [Flow] in an [Envelope] whose id is derived via [id].
  */
-@OptIn(ExperimentalUuidApi::class)
 inline fun <reified T> Flow<T>.mapToEnvelope(
-    crossinline id: (T) -> String = { Uuid.random().toString() },
+    crossinline id: (T) -> String,
 ): Flow<Envelope<T>> = map { input ->
     input.asEnvelope(
         id = id(input),
@@ -47,27 +51,46 @@ inline fun <reified T> Flow<T>.mapToEnvelope(
 }
 
 /**
- * Extension function to map a Flow of inputs to a Flow of Envelopes containing the inputs.
- *
- * @param id A function to generate an ID for each input. Defaults to a random UUID.
- * @return A Flow emitting Envelopes containing the inputs.
+ * Wraps each element of this [Flow] in an [Envelope] with the given [type], whose id
+ * is derived via [id].
  */
-@OptIn(ExperimentalUuidApi::class)
 fun <T> Flow<T>.mapToEnvelope(
     type: String,
-    id: (T) -> String = { Uuid.random().toString() },
+    id: (T) -> String,
 ): Flow<Envelope<T>> = map { input ->
     input.asEnvelopeWithType(
         id = id(input),
-        type = type
+        type = type,
     )
 }
+
+// =====================================================================================
+// Explicit random-id opt-in variants — for fire-and-forget cases (output wrappings,
+// anonymous transforms) where caller-side correlation is not needed.
+// =====================================================================================
+
+@OptIn(ExperimentalUuidApi::class)
+inline fun <T, reified R> F2Function<T, R>.mapToEnvelopeWithRandomId(): F2Function<T, Envelope<R>> =
+    mapToEnvelope { Uuid.random().toString() }
+
+@OptIn(ExperimentalUuidApi::class)
+inline fun <reified T> Flow<T>.mapToEnvelopeWithRandomId(): Flow<Envelope<T>> =
+    mapToEnvelope { Uuid.random().toString() }
+
+@OptIn(ExperimentalUuidApi::class)
+fun <T> Flow<T>.mapToEnvelopeWithRandomId(
+    type: String,
+): Flow<Envelope<T>> = mapToEnvelope(type) { Uuid.random().toString() }
+
+// =====================================================================================
+// Envelope-preserving transformations — unchanged.
+// =====================================================================================
 
 suspend inline fun <T, reified R> Envelope<T>.mapEnvelope(
     crossinline transform: suspend (value: T) -> R,
     source: String? = null,
     id: String = this.id,
-    type: String =  R::class.simpleName ?: "Unknown",
+    type: String = R::class.simpleName ?: "Unknown",
     time: String? = null,
     datacontenttype: String? = null
 ): Envelope<R> {
@@ -83,29 +106,16 @@ suspend fun <T, R> Envelope<T>.mapEnvelopeWithType(
     time: String? = null,
     datacontenttype: String? = null
 ): Envelope<R> {
-    return transform(data).asEnvelopeWithType(type,this, source, id, time, datacontenttype)
+    return transform(data).asEnvelopeWithType(type, this, source, id, time, datacontenttype)
 }
 
 
-
-/**
- * Extension function to map a Flow of inputs to a Flow of Envelopes containing the inputs.
- *
- * @param id A function to generate an ID for each input. Defaults to a random UUID.
- * @return A Flow emitting Envelopes containing the inputs.
- */
 inline fun <T, reified R> Flow<Envelope<T>>.mapEnvelopesReified(
     crossinline transform: suspend (value: T) -> R
 ): Flow<Envelope<R>> = map { input ->
     input.mapEnvelope(transform)
 }
 
-/**
- * Extension function to map a Flow of inputs to a Flow of Envelopes containing the inputs.
- *
- * @param id A function to generate an ID for each input. Defaults to a random UUID.
- * @return A Flow emitting Envelopes containing the inputs.
- */
 fun <T, R> Flow<Envelope<T>>.mapEnvelopes(
     transform: suspend (value: T) -> R,
     type: String

--- a/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/EnvelopeWrapTest.kt
+++ b/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/EnvelopeWrapTest.kt
@@ -24,7 +24,7 @@ class EnvelopeWrapTest {
         )
 
         // Invoke the wrapped function with the Flow of envelopes
-        val results: Flow<Envelope<String>> = myFunction.mapToEnvelope().invoke(envelopes)
+        val results: Flow<Envelope<String>> = myFunction.mapToEnvelopeWithRandomId().invoke(envelopes)
         val collectedResults = results.toList()
 
         // Assert the results using AssertJ

--- a/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/MapToEnvelopeRequiredIdTest.kt
+++ b/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/MapToEnvelopeRequiredIdTest.kt
@@ -1,0 +1,70 @@
+package f2.dsl.fnc.operators
+
+import f2.dsl.fnc.F2Function
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * mapToEnvelope no longer accepts a default random-id. Callers must either
+ *  - provide an `id` extractor (preserves caller-supplied correlation), or
+ *  - opt in explicitly via `mapToEnvelopeWithRandomId(...)`.
+ *
+ * These tests pin the new behaviour. The fix that removes the default would
+ * break correlation across the s2/ssm/plateform pipeline if a downstream
+ * caller silently reverted to random ids — these tests trip first.
+ */
+class MapToEnvelopeRequiredIdTest {
+
+    private data class Cmd(val msgId: String, val payload: String)
+
+    @Test
+    suspend fun `Flow mapToEnvelope preserves caller-supplied id`() {
+        val cmds = flowOf(Cmd("m-1", "a"), Cmd("m-2", "b"), Cmd("m-3", "c"))
+        val envelopes = cmds.mapToEnvelope { it.msgId }.toList()
+        assertThat(envelopes.map { it.id }).containsExactly("m-1", "m-2", "m-3")
+        assertThat(envelopes.map { it.data.payload }).containsExactly("a", "b", "c")
+    }
+
+    @Test
+    suspend fun `Flow mapToEnvelope with type preserves caller-supplied id`() {
+        val cmds = flowOf(Cmd("m-1", "a"), Cmd("m-2", "b"))
+        val envelopes = cmds.mapToEnvelope(type = "Cmd") { it.msgId }.toList()
+        assertThat(envelopes.map { it.id }).containsExactly("m-1", "m-2")
+        assertThat(envelopes).allMatch { it.type == "Cmd" }
+    }
+
+    @Test
+    suspend fun `F2Function mapToEnvelope preserves caller-supplied id`() {
+        val fn = F2Function<Cmd, String> { flow -> flow.map { it.payload.uppercase() } }
+        val envelopes = fn.mapToEnvelope { it.msgId }.invoke(
+            flowOf(Cmd("m-1", "a"), Cmd("m-2", "b"))
+        ).toList()
+        assertThat(envelopes.map { it.id }).containsExactly("m-1", "m-2")
+        assertThat(envelopes.map { it.data }).containsExactly("A", "B")
+    }
+
+    @Test
+    suspend fun `Flow mapToEnvelopeWithRandomId generates distinct UUIDs`() {
+        val envelopes = flowOf(1, 2, 3).mapToEnvelopeWithRandomId().toList()
+        assertThat(envelopes.map { it.id }.distinct()).hasSize(3)
+        assertThat(envelopes.map { it.data }).containsExactly(1, 2, 3)
+    }
+
+    @Test
+    suspend fun `Flow mapToEnvelopeWithRandomId with type generates UUIDs and sets type`() {
+        val envelopes = flowOf("x", "y").mapToEnvelopeWithRandomId(type = "Anon").toList()
+        assertThat(envelopes.map { it.id }.distinct()).hasSize(2)
+        assertThat(envelopes).allMatch { it.type == "Anon" }
+    }
+
+    @Test
+    suspend fun `F2Function mapToEnvelopeWithRandomId generates distinct UUIDs`() {
+        val fn = F2Function<Int, String> { flow -> flow.map { it.toString() } }
+        val envelopes = fn.mapToEnvelopeWithRandomId().invoke(flowOf(1, 2, 3)).toList()
+        assertThat(envelopes.map { it.id }.distinct()).hasSize(3)
+        assertThat(envelopes.map { it.data }).containsExactly("1", "2", "3")
+    }
+}

--- a/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/MapToEnvelopeTest.kt
+++ b/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/MapToEnvelopeTest.kt
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test
 class MapToEnvelopeTest {
 
     @Test
-    suspend fun `test mapToEnvelope with default ID`() {
+    suspend fun `test mapToEnvelopeWithRandomId on F2Function`() {
         val function = F2Function<Int, String> { flow -> flow.map { it.toString() } }
-        val result = function.mapToEnvelope().invoke(flowOf(1, 2, 3)).toList()
+        val result = function.mapToEnvelopeWithRandomId().invoke(flowOf(1, 2, 3)).toList()
         assertThat(result).hasSize(3)
         assertThat(result.map { it.data }).containsExactly("1", "2", "3")
     }
@@ -28,9 +28,9 @@ class MapToEnvelopeTest {
 
 
     @Test
-    suspend fun `test mapToEnvelope with default ID function`() {
+    suspend fun `test mapToEnvelopeWithRandomId on Flow`() {
         val flow = flowOf(1, 2, 3)
-        val result = flow.mapToEnvelope().toList()
+        val result = flow.mapToEnvelopeWithRandomId().toList()
         assertThat(result).hasSize(3)
         result.forEach { envelope ->
             assertThat(envelope.id).isNotNull()


### PR DESCRIPTION
## Summary

`mapToEnvelope(type)` (and reified variants) silently defaulted the envelope id to `Uuid.random().toString()`. That default was load-bearing in s2's `evolveWithOutcomes` path — the envelope id flows through to `PersistOutcome.msgId`, which downstream callers use to correlate outcomes back to source commands. Random-by-default severed that correlation, leaving failure events with blank identity fields in production.

This is the root-cause framework fix for a stuck-wrappers bug surfaced in a Colis Activ SSM export pipeline (365 wrappers retried forever, never decrementing `retriesLeft`, because every failure response came back with `wrapperId=""`).

### BREAKING CHANGE

Callers must now supply an `id` extractor or opt in to random ids via `mapToEnvelopeWithRandomId(...)`. No silent default.

| API | Use when |
|---|---|
| `mapToEnvelope(type, id)` | correlation-sensitive paths (any caller that surfaces failure routing) |
| `mapToEnvelopeWithRandomId(type)` | fire-and-forget cases (output wrappings, anonymous transforms) |

## Coordinated PRs

This PR is the deepest in a 4-repo dependency chain. Merge order:

1. **fixers-f2 (this PR)** — adds the new shape
2. **fixers-s2** — propagates `idOf` through `evolveWithOutcomes`
3. **colisactiv-ssm** — passes `cmd.msgId` as `idOf` in DeliveryDeciderImpl
4. **plateform** — hardens `logResponse` per-row tolerance as defense in depth

## Test plan

- [x] `MapToEnvelopeRequiredIdTest` — new test, pins `mapToEnvelope(type, id)` preserves caller id
- [x] `MapToEnvelopeRequiredIdTest` — new test, pins `mapToEnvelopeWithRandomId(type)` generates UUIDs
- [x] Existing `MapToEnvelopeTest` / `EnvelopeWrapTest` updated to use the explicit form
- [x] f2-dsl-function `jvmTest` green
- [x] Verified end-to-end against a running stack: stuck wrappers transitioned out of PENDING after the full chain landed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * ID generation now must be supplied explicitly by callers instead of being implicitly randomized, improving caller control over message correlation.

* **New Features**
  * Added convenience helpers that produce random IDs when automatic random ID behavior is desired.

* **Tests**
  * Updated and added tests to validate required-ID behavior and the new random-ID helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->