### PR TITLE
test: improve coverage and reduce duplication for SonarQube quality gate

### DIFF
--- a/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaListStepsBase.kt
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaListStepsBase.kt
@@ -1,43 +1,10 @@
 package f2.bdd.spring.autoconfigure.steps
 
 import f2.bdd.spring.autoconfigure.utils.ConsumerReceiver
-import io.cucumber.datatable.DataTable
-import io.cucumber.java8.En
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 
-@Suppress("TooManyFunctions")
-abstract class LambdaListStepsBase<P, R> : F2SpringStep() {
-
-	@Suppress("LongMethod")
-	fun En.prepareLambdaSteps(
-		functionName: String,
-		supplierName: String,
-		consumerName: String,
-	) {
-		prepareSteps()
-
-		When("Execute function $functionName with") { dataTable: DataTable ->
-			bag.result[functionName] = function(transform(dataTable))
-		}
-
-		When("Execute supplier $supplierName") {
-			bag.result[supplierName] = supplier()
-		}
-
-		When("Execute consumer $consumerName with") { dataTable: DataTable ->
-			runBlocking {
-				consumer(transform(dataTable))
-				delay(timeMillis = 1000)
-				val receiver = receiver()
-				bag.result[consumerName] = receiver.items
-			}
-		}
-	}
+abstract class LambdaListStepsBase<P, R> : LambdaStepsBase<List<P>, List<R>>() {
 
 	abstract fun receiver(): ConsumerReceiver<P>
-	abstract fun transform(dataTable: DataTable): List<P>
-	abstract fun function(values: List<P>): List<R>
-	abstract fun supplier(): List<R>
-	abstract fun consumer(values: List<P>)
+
+	override fun consumedItems(): Any = receiver().items
 }

--- a/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaSingleStepsBase.kt
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaSingleStepsBase.kt
@@ -1,43 +1,10 @@
 package f2.bdd.spring.autoconfigure.steps
 
 import f2.bdd.spring.autoconfigure.utils.ConsumerReceiver
-import io.cucumber.datatable.DataTable
-import io.cucumber.java8.En
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 
-@Suppress("TooManyFunctions")
-abstract class LambdaSingleStepsBase<P, R> : F2SpringStep() {
-
-	@Suppress("LongMethod")
-	fun En.prepareLambdaSteps(
-		functionName: String,
-		supplierName: String,
-		consumerName: String,
-	) {
-		prepareSteps()
-
-		When("Execute function $functionName with") { dataTable: DataTable ->
-			bag.result[functionName] = function(transform(dataTable)) as Any
-		}
-
-		When("Execute supplier $supplierName") {
-			bag.result[supplierName] = supplier() as Any
-		}
-
-		When("Execute consumer $consumerName with") { dataTable: DataTable ->
-			runBlocking {
-				consumer(transform(dataTable))
-				delay(timeMillis = 1000)
-				val receiver = receiver()
-				bag.result[consumerName] = receiver.items.first() as Any
-			}
-		}
-	}
+abstract class LambdaSingleStepsBase<P, R> : LambdaStepsBase<P, R>() {
 
 	abstract fun receiver(): ConsumerReceiver<P>
-	abstract fun transform(dataTable: DataTable): P
-	abstract fun function(values: P): R
-	abstract fun supplier(): R
-	abstract fun consumer(values: P)
+
+	override fun consumedItems(): Any = receiver().items.first() as Any
 }

--- a/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaStepsBase.kt
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/LambdaStepsBase.kt
@@ -1,0 +1,39 @@
+package f2.bdd.spring.autoconfigure.steps
+
+import io.cucumber.datatable.DataTable
+import io.cucumber.java8.En
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+abstract class LambdaStepsBase<P, R> : F2SpringStep() {
+
+	fun En.prepareLambdaSteps(
+		functionName: String,
+		supplierName: String,
+		consumerName: String,
+	) {
+		prepareSteps()
+
+		When("Execute function $functionName with") { dataTable: DataTable ->
+			bag.result[functionName] = function(transform(dataTable)) as Any
+		}
+
+		When("Execute supplier $supplierName") {
+			bag.result[supplierName] = supplier() as Any
+		}
+
+		When("Execute consumer $consumerName with") { dataTable: DataTable ->
+			runBlocking {
+				consumer(transform(dataTable))
+				delay(timeMillis = 1000)
+				bag.result[consumerName] = consumedItems()
+			}
+		}
+	}
+
+	protected abstract fun consumedItems(): Any
+	abstract fun transform(dataTable: DataTable): P
+	abstract fun function(values: P): R
+	abstract fun supplier(): R
+	abstract fun consumer(values: P)
+}

--- a/f2-feature/catalog/f2-feature-catalog/build.gradle.kts
+++ b/f2-feature/catalog/f2-feature-catalog/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 
 dependencies {
     api(libs.bundles.spring.cloud.function)
+
+    testImplementation(libs.bundles.spring.test)
 }

--- a/f2-feature/catalog/f2-feature-catalog/src/main/kotlin/f2/feature/catalog/CatalogFunctionConfig.kt
+++ b/f2-feature/catalog/f2-feature-catalog/src/main/kotlin/f2/feature/catalog/CatalogFunctionConfig.kt
@@ -1,6 +1,7 @@
 package f2.feature.catalog
 
 import java.util.function.Consumer
+import java.util.function.Function
 import java.util.function.Supplier
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.function.context.FunctionCatalog

--- a/f2-feature/catalog/f2-feature-catalog/src/test/kotlin/f2/feature/catalog/CatalogFunctionConfigTest.kt
+++ b/f2-feature/catalog/f2-feature-catalog/src/test/kotlin/f2/feature/catalog/CatalogFunctionConfigTest.kt
@@ -1,6 +1,7 @@
 package f2.feature.catalog
 
 import java.util.function.Consumer
+import java.util.function.Function
 import java.util.function.Supplier
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/f2-feature/catalog/f2-feature-catalog/src/test/kotlin/f2/feature/catalog/CatalogFunctionConfigTest.kt
+++ b/f2-feature/catalog/f2-feature-catalog/src/test/kotlin/f2/feature/catalog/CatalogFunctionConfigTest.kt
@@ -1,0 +1,46 @@
+package f2.feature.catalog
+
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cloud.function.context.FunctionCatalog
+
+class CatalogFunctionConfigTest {
+
+    private val functionCatalog = object : FunctionCatalog {
+        override fun <T> lookup(
+            type: Class<*>?,
+            functionDefinition: String?,
+            vararg expectedOutputMimeTypes: String?
+        ): T? {
+            return null
+        }
+
+        override fun getNames(type: Class<*>?): Set<String> = when (type) {
+            Function::class.java -> setOf("myFunction", "&internalFunction")
+            Supplier::class.java -> setOf("mySupplier", "&internalSupplier")
+            Consumer::class.java -> setOf("myConsumer", "&internalConsumer")
+            else -> emptySet()
+        }
+    }
+
+    private val config = CatalogFunctionConfig().apply {
+        catalog = functionCatalog
+    }
+
+    @Test
+    fun `catalogFunction should list function names without internal ones`() {
+        assertThat(config.catalogFunction()()).containsExactly("myFunction")
+    }
+
+    @Test
+    fun `catalogSupplier should list supplier names without internal ones`() {
+        assertThat(config.catalogSupplier()()).containsExactly("mySupplier")
+    }
+
+    @Test
+    fun `catalogConsumer should list consumer names without internal ones`() {
+        assertThat(config.catalogConsumer()()).containsExactly("myConsumer")
+    }
+}

--- a/f2-feature/version/f2-feature-version/build.gradle.kts
+++ b/f2-feature/version/f2-feature-version/build.gradle.kts
@@ -7,4 +7,6 @@ dependencies {
     api(project(":f2-spring:function:f2-spring-boot-starter-function"))
 
     api(libs.spring.boot.autoconfigure)
+
+    testImplementation(libs.bundles.spring.test)
 }

--- a/f2-feature/version/f2-feature-version/src/test/kotlin/f2/feature/version/DefaultFunctionConfigTest.kt
+++ b/f2-feature/version/f2-feature-version/src/test/kotlin/f2/feature/version/DefaultFunctionConfigTest.kt
@@ -1,0 +1,39 @@
+package f2.feature.version
+
+import java.util.Properties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.info.BuildProperties
+
+class DefaultFunctionConfigTest {
+
+    private fun config(properties: Properties): DefaultFunctionConfig {
+        return DefaultFunctionConfig().apply {
+            buildProperties = BuildProperties(properties)
+        }
+    }
+
+    @Test
+    fun `version should return build version`() {
+        val config = config(Properties().apply { setProperty("version", "1.2.3") })
+        assertThat(config.version()()).isEqualTo("1.2.3")
+    }
+
+    @Test
+    fun `version should default to dev when missing`() {
+        val config = config(Properties())
+        assertThat(config.version()()).isEqualTo("dev")
+    }
+
+    @Test
+    fun `name should return build name`() {
+        val config = config(Properties().apply { setProperty("name", "my-app") })
+        assertThat(config.name()()).isEqualTo("my-app")
+    }
+
+    @Test
+    fun `name should default to dev when missing`() {
+        val config = config(Properties())
+        assertThat(config.name()()).isEqualTo("dev")
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/build.gradle.kts
@@ -7,4 +7,6 @@ plugins {
 dependencies {
     api(libs.spring.boot.starter.security)
     api(libs.bundles.spring.oauth2)
+
+    testImplementation(libs.bundles.spring.test)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProviderTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProviderTest.kt
@@ -1,0 +1,148 @@
+package io.komune.f2.spring.boot.auth
+
+import kotlinx.coroutines.reactor.asCoroutineContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import reactor.core.publisher.Mono
+import reactor.util.context.Context
+
+class AuthenticationProviderTest {
+
+    companion object {
+        const val ISSUER = "http://localhost:8080/auth/realms/tenant-1"
+        const val ORGANIZATION_ID = "organization-1"
+        const val CLIENT_ID = "client-1"
+    }
+
+    private fun jwt(issuer: String = ISSUER): Jwt = Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .issuer(issuer)
+        .claim(ORGANIZATION_ID_CLAIM_NAME, ORGANIZATION_ID)
+        .claim(AZP_CLAIM_NAME, CLIENT_ID)
+        .build()
+
+    private fun authentication(jwt: Jwt, vararg roles: String) = JwtAuthenticationToken(
+        jwt,
+        roles.map { role -> SimpleGrantedAuthority("$ROLE_PREFIX$role") }
+    )
+
+    private fun <T> withSecurityContext(
+        authentication: JwtAuthenticationToken,
+        block: suspend () -> T
+    ): T = runBlocking {
+        val securityContext: SecurityContext = SecurityContextImpl(authentication)
+        val reactorContext = Context.of(
+            SecurityContext::class.java,
+            Mono.just(securityContext)
+        )
+        withContext(reactorContext.asCoroutineContext()) {
+            block()
+        }
+    }
+
+    @Test
+    fun `getSecurityContext should return null without reactor context`() = runBlocking<Unit> {
+        assertThat(AuthenticationProvider.getSecurityContext()).isNull()
+        assertThat(AuthenticationProvider.getAuthentication()).isNull()
+        assertThat(AuthenticationProvider.getPrincipal()).isNull()
+        assertThat(AuthenticationProvider.getOrganizationId()).isNull()
+        assertThat(AuthenticationProvider.getIssuer()).isNull()
+        assertThat(AuthenticationProvider.getClientId()).isNull()
+        assertThat(AuthenticationProvider.getTenant()).isNull()
+    }
+
+    @Test
+    fun `getSecurityContext should return context from coroutine reactor context`() {
+        val securityContext = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getSecurityContext()
+        }
+        assertThat(securityContext).isNotNull
+        assertThat(securityContext!!.authentication).isInstanceOf(JwtAuthenticationToken::class.java)
+    }
+
+    @Test
+    fun `getAuthentication should return the jwt authentication token`() {
+        val authentication = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getAuthentication()
+        }
+        assertThat(authentication).isNotNull
+        assertThat(authentication!!.token.tokenValue).isEqualTo("token")
+    }
+
+    @Test
+    fun `getPrincipal should return the jwt`() {
+        val principal = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getPrincipal()
+        }
+        assertThat(principal).isNotNull
+        assertThat(principal!!.tokenValue).isEqualTo("token")
+    }
+
+    @Test
+    fun `getOrganizationId should return memberOf claim`() {
+        val organizationId = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getOrganizationId()
+        }
+        assertThat(organizationId).isEqualTo(ORGANIZATION_ID)
+    }
+
+    @Test
+    fun `getIssuer should return issuer claim`() {
+        val issuer = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getIssuer()
+        }
+        assertThat(issuer).isEqualTo(ISSUER)
+    }
+
+    @Test
+    fun `getClientId should return azp claim`() {
+        val clientId = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getClientId()
+        }
+        assertThat(clientId).isEqualTo(CLIENT_ID)
+    }
+
+    @Test
+    fun `getTenant should return last segment of issuer`() {
+        val tenant = withSecurityContext(authentication(jwt())) {
+            AuthenticationProvider.getTenant()
+        }
+        assertThat(tenant).isEqualTo("tenant-1")
+    }
+
+    @Test
+    fun `getTenant should return null when issuer ends with slash`() {
+        val tenant = withSecurityContext(authentication(jwt(issuer = "http://localhost:8080/"))) {
+            AuthenticationProvider.getTenant()
+        }
+        assertThat(tenant).isNull()
+    }
+
+    @Test
+    fun `hasRole should return true when authority is present`() {
+        val hasRole = withSecurityContext(authentication(jwt(), "admin")) {
+            AuthenticationProvider.hasRole("admin")
+        }
+        assertThat(hasRole).isTrue()
+    }
+
+    @Test
+    fun `hasRole should return false when authority is missing`() {
+        val hasRole = withSecurityContext(authentication(jwt(), "user")) {
+            AuthenticationProvider.hasRole("admin")
+        }
+        assertThat(hasRole).isFalse()
+    }
+
+    @Test
+    fun `hasRole should return false without authentication`() = runBlocking<Unit> {
+        assertThat(AuthenticationProvider.hasRole("admin")).isFalse()
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluatorTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluatorTest.kt
@@ -1,0 +1,89 @@
+package io.komune.f2.spring.boot.auth
+
+import kotlinx.coroutines.reactor.asCoroutineContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import reactor.core.publisher.Mono
+import reactor.util.context.Context
+
+class PermissionEvaluatorTest {
+
+    private val permissionEvaluator = PermissionEvaluator()
+
+    private fun jwt(): Jwt = Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .claim(ORGANIZATION_ID_CLAIM_NAME, "organization-1")
+        .build()
+
+    private fun <T> withAuthentication(
+        vararg roles: String,
+        block: suspend () -> T
+    ): T = runBlocking {
+        val authentication = JwtAuthenticationToken(
+            jwt(),
+            roles.map { role -> SimpleGrantedAuthority("$ROLE_PREFIX$role") }
+        )
+        val securityContext: SecurityContext = SecurityContextImpl(authentication)
+        val reactorContext = Context.of(
+            SecurityContext::class.java,
+            Mono.just(securityContext)
+        )
+        withContext(reactorContext.asCoroutineContext()) {
+            block()
+        }
+    }
+
+    @Test
+    fun `isSuperAdmin should return true with super_admin role`() {
+        val isSuperAdmin = withAuthentication(SUPER_ADMIN_ROLE) {
+            permissionEvaluator.isSuperAdmin()
+        }
+        assertThat(isSuperAdmin).isTrue()
+    }
+
+    @Test
+    fun `isSuperAdmin should return false without super_admin role`() {
+        val isSuperAdmin = withAuthentication("user") {
+            permissionEvaluator.isSuperAdmin()
+        }
+        assertThat(isSuperAdmin).isFalse()
+    }
+
+    @Test
+    fun `isSuperAdmin should return false without authentication`() = runBlocking<Unit> {
+        assertThat(permissionEvaluator.isSuperAdmin()).isFalse()
+    }
+
+    @Test
+    fun `checkOrganizationId should return false for null organizationId`() = runBlocking<Unit> {
+        assertThat(permissionEvaluator.checkOrganizationId(null)).isFalse()
+    }
+
+    @Test
+    fun `checkOrganizationId should return true when it matches the authenticated organization`() {
+        val checked = withAuthentication("user") {
+            permissionEvaluator.checkOrganizationId("organization-1")
+        }
+        assertThat(checked).isTrue()
+    }
+
+    @Test
+    fun `checkOrganizationId should return false when it does not match`() {
+        val checked = withAuthentication("user") {
+            permissionEvaluator.checkOrganizationId("organization-2")
+        }
+        assertThat(checked).isFalse()
+    }
+
+    @Test
+    fun `checkOrganizationId should return false without authentication`() = runBlocking<Unit> {
+        assertThat(permissionEvaluator.checkOrganizationId("organization-1")).isFalse()
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
@@ -6,4 +6,6 @@ plugins {
 
 dependencies {
     api(project(":f2-spring:auth:f2-spring-boot-starter-auth"))
+
+    testImplementation(libs.bundles.spring.test)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigResolverTest.kt
@@ -1,0 +1,77 @@
+package io.komune.f2.spring.boot.auth.keycloak
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class KeycloakConfigResolverTest {
+
+    private val f2KeycloakConfig = F2KeycloakConfig(
+        issuers = listOf(
+            KeycloakIssuers(
+                name = "first",
+                authUrl = "http://localhost:8080/auth",
+                realm = "master",
+                web = I2KeycloakProperties(clientId = "web-client")
+            ),
+            KeycloakIssuers(
+                name = "second",
+                authUrl = "http://localhost:8081/auth",
+                realm = "tenant",
+                web = null
+            )
+        )
+    )
+    private val resolver = KeycloakConfigResolver(f2KeycloakConfig)
+
+    @Test
+    fun `getConfig should map issuers by name`() {
+        val config = f2KeycloakConfig.getConfig()
+
+        assertThat(config).containsOnlyKeys("first", "second")
+        assertThat(config["first"]).isEqualTo(
+            KeycloakConfig(realm = "master", authServerUrl = "http://localhost:8080/auth", resource = "web-client")
+        )
+        assertThat(config["second"]).isEqualTo(
+            KeycloakConfig(realm = "tenant", authServerUrl = "http://localhost:8081/auth", resource = null)
+        )
+    }
+
+    @Test
+    fun `getKeycloakConfig should return first config for null name`() = runBlocking<Unit> {
+        val config = resolver.getKeycloakConfig(null)
+        assertThat(config.realm).isEqualTo("master")
+    }
+
+    @Test
+    fun `getKeycloakConfig should return first config for blank name`() = runBlocking<Unit> {
+        val config = resolver.getKeycloakConfig("")
+        assertThat(config.realm).isEqualTo("master")
+    }
+
+    @Test
+    fun `getKeycloakConfig should return config matching the name`() = runBlocking<Unit> {
+        val config = resolver.getKeycloakConfig("second")
+        assertThat(config.realm).isEqualTo("tenant")
+    }
+
+    @Test
+    fun `getKeycloakConfig should fail for unknown name`() {
+        assertThatThrownBy {
+            runBlocking { resolver.getKeycloakConfig("unknown") }
+        }.isInstanceOf(NullPointerException::class.java)
+            .hasMessageContaining("unknown")
+    }
+
+    @Test
+    fun `keycloak endpoint function should return the resolved config`() {
+        val endpoint = KeycloakConfigEndpoint(resolver)
+
+        val config = endpoint.keycloak()("first")
+
+        assertThat(config).isEqualTo(
+            KeycloakConfig(realm = "master", authServerUrl = "http://localhost:8080/auth", resource = "web-client")
+        )
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
     api(project(":f2-spring:auth:f2-spring-boot-starter-auth-commons"))
     api(libs.spring.boot.starter.security)
     api(libs.bundles.spring.oauth2)
+
+    testImplementation(libs.bundles.spring.test)
+    testImplementation(libs.spring.boot.starter.webflux)
 }
 
 

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigTest.kt
@@ -1,0 +1,97 @@
+package io.komune.f2.spring.boot.auth.config
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.WebFilterChainProxy
+import reactor.core.publisher.Mono
+
+class WebSecurityConfigTest {
+
+    @Configuration
+    open class SecuredBeansConfig {
+        @Bean("securedFunction")
+        @RolesAllowed("admin")
+        open fun securedFunction(): () -> String = { "secured" }
+
+        @Bean("openFunction")
+        @PermitAll
+        open fun openFunction(): () -> String = { "open" }
+    }
+
+    class TestServerHttpSecurity : ServerHttpSecurity() {
+        fun withApplicationContext(context: ApplicationContext): TestServerHttpSecurity = apply {
+            setApplicationContext(context)
+        }
+    }
+
+    private lateinit var beansContext: AnnotationConfigApplicationContext
+    private lateinit var config: WebSecurityConfig
+
+    @BeforeEach
+    fun setUp() {
+        beansContext = AnnotationConfigApplicationContext(SecuredBeansConfig::class.java)
+        config = WebSecurityConfig().apply {
+            contextPath = ""
+            applicationContext = beansContext
+            f2TrustedIssuersResolver = F2TrustedIssuersConfig(
+                issuerBaseUri = "http://localhost:8080/auth/realms/"
+            )
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        beansContext.close()
+    }
+
+    private fun http() = TestServerHttpSecurity().withApplicationContext(beansContext)
+
+    @Test
+    fun `authFilter should return an empty map by default`() {
+        assertThat(config.authFilter()).isEmpty()
+    }
+
+    @Test
+    fun `dummyAuthenticationProvider should build a permit all filter chain`() {
+        val chain = config.dummyAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/anything"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `oauthAuthenticationProvider should reject unauthenticated requests`() {
+        val chain = config.oauthAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/securedFunction"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    fun `oauthAuthenticationProvider should permit beans annotated with PermitAll`() {
+        val chain = config.oauthAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/openFunction"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.FORBIDDEN)
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
@@ -1,8 +1,12 @@
 package io.komune.f2.spring.boot.auth.security
 
+import com.sun.net.httpserver.HttpServer
 import io.komune.f2.spring.boot.auth.ROLE_PREFIX
 import io.komune.f2.spring.boot.auth.config.F2TrustedIssuersConfig
+import java.net.InetSocketAddress
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
@@ -10,11 +14,47 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 class TrustedIssuerJwtAuthenticationManagerResolverTest {
 
     companion object {
-        const val ISSUER_BASE_URI = "http://localhost:8080/auth/realms/"
+        private const val TENANT_PATH = "/auth/realms/tenant-1"
+
+        private lateinit var server: HttpServer
+        private lateinit var issuerBaseUri: String
+        private lateinit var trustedIssuer: String
+
+        @JvmStatic
+        @BeforeAll
+        fun startOidcProviderStub() {
+            server = HttpServer.create(InetSocketAddress(0), 0)
+            issuerBaseUri = "http://localhost:${server.address.port}/auth/realms/"
+            trustedIssuer = "http://localhost:${server.address.port}$TENANT_PATH"
+            server.createContext("$TENANT_PATH/.well-known/openid-configuration") { exchange ->
+                val body = """
+                    {
+                      "issuer": "$trustedIssuer",
+                      "jwks_uri": "$trustedIssuer/protocol/openid-connect/certs"
+                    }
+                """.trimIndent().toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.createContext("$TENANT_PATH/protocol/openid-connect/certs") { exchange ->
+                val body = """{"keys":[]}""".toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() {
+            server.stop(0)
+        }
     }
 
     private val resolver = TrustedIssuerJwtAuthenticationManagerResolver(
-        trustedIssuersConfig = F2TrustedIssuersConfig(issuerBaseUri = ISSUER_BASE_URI)
+        trustedIssuersConfig = F2TrustedIssuersConfig(issuerBaseUri = issuerBaseUri)
     )
 
     @Test
@@ -25,13 +65,14 @@ class TrustedIssuerJwtAuthenticationManagerResolverTest {
 
     @Test
     fun `resolve should return a manager mono for issuer within the base uri`() {
-        assertThat(resolver.resolve("${ISSUER_BASE_URI}tenant-1")).isNotNull
+        val manager = resolver.resolve(trustedIssuer).block()
+        assertThat(manager).isNotNull
     }
 
     @Test
     fun `resolve should cache the manager mono per issuer`() {
-        val first = resolver.resolve("${ISSUER_BASE_URI}tenant-1")
-        val second = resolver.resolve("${ISSUER_BASE_URI}tenant-1")
+        val first = resolver.resolve(trustedIssuer)
+        val second = resolver.resolve(trustedIssuer)
         assertThat(second).isSameAs(first)
     }
 

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
@@ -1,0 +1,76 @@
+package io.komune.f2.spring.boot.auth.security
+
+import io.komune.f2.spring.boot.auth.ROLE_PREFIX
+import io.komune.f2.spring.boot.auth.config.F2TrustedIssuersConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class TrustedIssuerJwtAuthenticationManagerResolverTest {
+
+    companion object {
+        const val ISSUER_BASE_URI = "http://localhost:8080/auth/realms/"
+    }
+
+    private val resolver = TrustedIssuerJwtAuthenticationManagerResolver(
+        trustedIssuersConfig = F2TrustedIssuersConfig(issuerBaseUri = ISSUER_BASE_URI)
+    )
+
+    @Test
+    fun `resolve should return empty mono for issuer outside of the base uri`() {
+        val manager = resolver.resolve("http://evil.example.com/realms/master").block()
+        assertThat(manager).isNull()
+    }
+
+    @Test
+    fun `resolve should return a manager mono for issuer within the base uri`() {
+        assertThat(resolver.resolve("${ISSUER_BASE_URI}tenant-1")).isNotNull
+    }
+
+    @Test
+    fun `resolve should cache the manager mono per issuer`() {
+        val first = resolver.resolve("${ISSUER_BASE_URI}tenant-1")
+        val second = resolver.resolve("${ISSUER_BASE_URI}tenant-1")
+        assertThat(second).isSameAs(first)
+    }
+
+    @Test
+    fun `jwtAuthoritiesConverter should map realm_access roles to prefixed authorities`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("realm_access", mapOf("roles" to listOf("admin", "user")))
+            .build()
+
+        val authorities = resolver.jwtAuthoritiesConverter(jwt).collectList().block()
+
+        assertThat(authorities!!.map { it.authority })
+            .containsExactly("${ROLE_PREFIX}admin", "${ROLE_PREFIX}user")
+    }
+
+    @Test
+    fun `jwtAuthoritiesConverter should return no authority without realm_access claim`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("sub", "user-1")
+            .build()
+
+        val authorities = resolver.jwtAuthoritiesConverter(jwt).collectList().block()
+
+        assertThat(authorities).isEmpty()
+    }
+
+    @Test
+    fun `jwtAuthenticationConverter should convert jwt to authentication token with authorities`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("realm_access", mapOf("roles" to listOf("admin")))
+            .build()
+
+        val authentication = resolver.jwtAuthenticationConverter().convert(jwt)!!.block()
+
+        assertThat(authentication).isInstanceOf(JwtAuthenticationToken::class.java)
+        assertThat(authentication!!.authorities.map { it.authority })
+            .containsExactly("${ROLE_PREFIX}admin")
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/build.gradle.kts
@@ -11,4 +11,7 @@ dependencies {
     api(libs.bundles.spring.oauth2)
 
     implementation(libs.spring.boot.autoconfigure)
+
+    testImplementation(libs.bundles.spring.test)
+    testImplementation(libs.spring.boot.starter.webflux)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfigTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/F2TrustedIssuersConfigTest.kt
@@ -1,0 +1,46 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class F2TrustedIssuersConfigTest {
+
+    @Test
+    fun `should build issuer from authUrl and realm`() {
+        val properties = TrustedIssuerProperties(
+            name = "keycloak",
+            authUrl = "http://localhost:8080/auth",
+            realm = "master"
+        )
+        assertThat(properties.issuer).isEqualTo("http://localhost:8080/auth/realms/master")
+    }
+
+    @Test
+    fun `should build issuer trimming authUrl trailing slash and realm leading slash`() {
+        val properties = TrustedIssuerProperties(
+            name = "keycloak",
+            authUrl = "http://localhost:8080/auth/",
+            realm = "/master"
+        )
+        assertThat(properties.issuer).isEqualTo("http://localhost:8080/auth/realms/master")
+    }
+
+    @Test
+    fun `getTrustedIssuers should return the issuers of all configured properties`() {
+        val config = F2TrustedIssuersConfig(
+            issuers = listOf(
+                TrustedIssuerProperties(name = "one", authUrl = "http://auth-1", realm = "realm-1"),
+                TrustedIssuerProperties(name = "two", authUrl = "http://auth-2", realm = "realm-2"),
+            )
+        )
+        assertThat(config.getTrustedIssuers()).containsExactly(
+            "http://auth-1/realms/realm-1",
+            "http://auth-2/realms/realm-2"
+        )
+    }
+
+    @Test
+    fun `getTrustedIssuers should return empty list by default`() {
+        assertThat(F2TrustedIssuersConfig().getTrustedIssuers()).isEmpty()
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
@@ -1,17 +1,55 @@
 package io.komune.f2.spring.boot.auth.config
 
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter
 
 class TrustedIssuerJwtAuthenticationManagerResolverTest {
 
     companion object {
-        const val TRUSTED_ISSUER = "http://localhost:8080/auth/realms/master"
+        private const val ISSUER_PATH = "/auth/realms/master"
+
+        private lateinit var server: HttpServer
+        private lateinit var trustedIssuer: String
+
+        @JvmStatic
+        @BeforeAll
+        fun startOidcProviderStub() {
+            server = HttpServer.create(InetSocketAddress(0), 0)
+            trustedIssuer = "http://localhost:${server.address.port}$ISSUER_PATH"
+            server.createContext("$ISSUER_PATH/.well-known/openid-configuration") { exchange ->
+                val body = """
+                    {
+                      "issuer": "$trustedIssuer",
+                      "jwks_uri": "$trustedIssuer/protocol/openid-connect/certs"
+                    }
+                """.trimIndent().toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.createContext("$ISSUER_PATH/protocol/openid-connect/certs") { exchange ->
+                val body = """{"keys":[]}""".toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() {
+            server.stop(0)
+        }
     }
 
     private val resolver = TrustedIssuerJwtAuthenticationManagerResolver(
-        isTrustedIssuer = { issuer -> issuer == TRUSTED_ISSUER },
+        isTrustedIssuer = { issuer -> issuer == trustedIssuer },
         reactiveJwtAuthenticationConverter = ReactiveJwtAuthenticationConverter()
     )
 
@@ -23,13 +61,14 @@ class TrustedIssuerJwtAuthenticationManagerResolverTest {
 
     @Test
     fun `resolve should return a manager mono for trusted issuer`() {
-        assertThat(resolver.resolve(TRUSTED_ISSUER)).isNotNull
+        val manager = resolver.resolve(trustedIssuer).block()
+        assertThat(manager).isNotNull
     }
 
     @Test
     fun `resolve should cache the manager mono per issuer`() {
-        val first = resolver.resolve(TRUSTED_ISSUER)
-        val second = resolver.resolve(TRUSTED_ISSUER)
+        val first = resolver.resolve(trustedIssuer)
+        val second = resolver.resolve(trustedIssuer)
         assertThat(second).isSameAs(first)
     }
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
@@ -1,0 +1,35 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter
+
+class TrustedIssuerJwtAuthenticationManagerResolverTest {
+
+    companion object {
+        const val TRUSTED_ISSUER = "http://localhost:8080/auth/realms/master"
+    }
+
+    private val resolver = TrustedIssuerJwtAuthenticationManagerResolver(
+        isTrustedIssuer = { issuer -> issuer == TRUSTED_ISSUER },
+        reactiveJwtAuthenticationConverter = ReactiveJwtAuthenticationConverter()
+    )
+
+    @Test
+    fun `resolve should return empty mono for untrusted issuer`() {
+        val manager = resolver.resolve("http://evil.example.com/realms/master").block()
+        assertThat(manager).isNull()
+    }
+
+    @Test
+    fun `resolve should return a manager mono for trusted issuer`() {
+        assertThat(resolver.resolve(TRUSTED_ISSUER)).isNotNull
+    }
+
+    @Test
+    fun `resolve should cache the manager mono per issuer`() {
+        val first = resolver.resolve(TRUSTED_ISSUER)
+        val second = resolver.resolve(TRUSTED_ISSUER)
+        assertThat(second).isSameAs(first)
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigTest.kt
@@ -1,0 +1,155 @@
+package io.komune.f2.spring.boot.auth.config
+
+import io.komune.f2.spring.boot.auth.ROLE_PREFIX
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.web.server.WebFilterChainProxy
+import reactor.core.publisher.Mono
+
+class WebSecurityConfigTest {
+
+    @Configuration
+    open class SecuredBeansConfig {
+        @Bean("securedFunction")
+        @RolesAllowed("admin")
+        open fun securedFunction(): () -> String = { "secured" }
+
+        @Bean("openFunction")
+        @PermitAll
+        open fun openFunction(): () -> String = { "open" }
+    }
+
+    class TestWebSecurityConfig : WebSecurityConfig()
+
+    class TestServerHttpSecurity : ServerHttpSecurity() {
+        fun withApplicationContext(context: ApplicationContext): TestServerHttpSecurity = apply {
+            setApplicationContext(context)
+        }
+    }
+
+    private lateinit var beansContext: AnnotationConfigApplicationContext
+    private lateinit var config: TestWebSecurityConfig
+
+    @BeforeEach
+    fun setUp() {
+        beansContext = AnnotationConfigApplicationContext(SecuredBeansConfig::class.java)
+        config = TestWebSecurityConfig().apply {
+            contextPath = ""
+            applicationContext = beansContext
+            f2TrustedIssuersResolver = F2TrustedIssuersConfig(
+                issuers = listOf(
+                    TrustedIssuerProperties(name = "keycloak", authUrl = "http://localhost:8080/auth", realm = "master")
+                )
+            )
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        beansContext.close()
+    }
+
+    private fun http() = TestServerHttpSecurity().withApplicationContext(beansContext)
+
+    @Test
+    fun `authFilter should return an empty map by default`() {
+        assertThat(config.authFilter()).isEmpty()
+    }
+
+    @Test
+    fun `trustedIssuers should expose configured issuers`() {
+        assertThat(config.trustedIssuers())
+            .containsExactly("http://localhost:8080/auth/realms/master")
+    }
+
+    @Test
+    fun `isTrustedIssuer should accept only configured issuers`() {
+        assertThat(config.isTrustedIssuer("http://localhost:8080/auth/realms/master")).isTrue()
+        assertThat(config.isTrustedIssuer("http://evil.example.com/realms/master")).isFalse()
+    }
+
+    @Test
+    fun `jwtAuthoritiesConverter should map realm_access roles to prefixed authorities`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("realm_access", mapOf("roles" to listOf("admin", "user")))
+            .build()
+
+        val authorities = config.jwtAuthoritiesConverter(jwt).collectList().block()
+
+        assertThat(authorities!!.map { it.authority })
+            .containsExactly("${ROLE_PREFIX}admin", "${ROLE_PREFIX}user")
+    }
+
+    @Test
+    fun `jwtAuthoritiesConverter should return no authority without realm_access claim`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("sub", "user-1")
+            .build()
+
+        val authorities = config.jwtAuthoritiesConverter(jwt).collectList().block()
+
+        assertThat(authorities).isEmpty()
+    }
+
+    @Test
+    fun `jwtAuthenticationConverter should convert jwt to authentication token with authorities`() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .claim("realm_access", mapOf("roles" to listOf("admin")))
+            .build()
+
+        val authentication = config.jwtAuthenticationConverter().convert(jwt)!!.block()
+
+        assertThat(authentication).isInstanceOf(JwtAuthenticationToken::class.java)
+        assertThat(authentication!!.authorities.map { it.authority })
+            .containsExactly("${ROLE_PREFIX}admin")
+    }
+
+    @Test
+    fun `dummyAuthenticationProvider should build a permit all filter chain`() {
+        val chain = config.dummyAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/anything"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `oauthAuthenticationProvider should reject unauthenticated requests`() {
+        val chain = config.oauthAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/securedFunction"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    fun `oauthAuthenticationProvider should permit beans annotated with PermitAll`() {
+        val chain = config.oauthAuthenticationProvider(http())
+
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/openFunction"))
+        WebFilterChainProxy(chain).filter(exchange) { _ -> Mono.empty() }.block()
+
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(exchange.response.statusCode).isNotEqualTo(HttpStatus.FORBIDDEN)
+    }
+}

--- a/f2-spring/exception/f2-spring-boot-exception-http-mvc/build.gradle.kts
+++ b/f2-spring/exception/f2-spring-boot-exception-http-mvc/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
     api(project(":f2-spring:exception:f2-spring-boot-exception-http"))
     api(libs.spring.boot.starter.web)
     implementation(libs.jackson.module.kotlin)
+
+    testImplementation(libs.bundles.spring.test)
 }

--- a/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/test/kotlin/f2/spring/exception/config/F2ErrorAttributesTest.kt
+++ b/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/test/kotlin/f2/spring/exception/config/F2ErrorAttributesTest.kt
@@ -1,0 +1,62 @@
+package f2.spring.exception.config
+
+import f2.dsl.cqrs.exception.F2Exception
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.ServletWebRequest
+
+class F2ErrorAttributesTest {
+
+    private val errorAttributes = F2ErrorAttributes()
+
+    private fun webRequest(exception: Throwable?): ServletWebRequest {
+        val request = MockHttpServletRequest()
+        request.setAttribute("jakarta.servlet.error.status_code", 500)
+        request.setAttribute("jakarta.servlet.error.request_uri", "/test")
+        if (exception != null) {
+            request.setAttribute("jakarta.servlet.error.exception", exception)
+        }
+        return ServletWebRequest(request)
+    }
+
+    @Test
+    fun `should enrich attributes with f2 error fields for F2Exception`() {
+        val exception = F2Exception(message = "Something broke", id = "error-id", code = 404)
+
+        val attributes = errorAttributes.getErrorAttributes(
+            webRequest(exception),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["id"]).isEqualTo("error-id")
+        assertThat(attributes["code"]).isEqualTo(404)
+        assertThat(attributes["message"]).isEqualTo("Something broke")
+        assertThat(attributes["timestamp"]).isNotNull
+    }
+
+    @Test
+    fun `should keep default attributes for non f2 exceptions`() {
+        val attributes = errorAttributes.getErrorAttributes(
+            webRequest(IllegalStateException("unexpected")),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["code"]).isNull()
+        assertThat(attributes["id"]).isNull()
+        assertThat(attributes["message"]).isEqualTo("unexpected")
+        assertThat(attributes["status"]).isEqualTo(500)
+    }
+
+    @Test
+    fun `should keep default attributes without exception`() {
+        val attributes = errorAttributes.getErrorAttributes(
+            webRequest(null),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["code"]).isNull()
+        assertThat(attributes["status"]).isEqualTo(500)
+    }
+}

--- a/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/test/kotlin/f2/spring/exception/config/F2ExceptionHandlerTest.kt
+++ b/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/test/kotlin/f2/spring/exception/config/F2ExceptionHandlerTest.kt
@@ -1,0 +1,61 @@
+package f2.spring.exception.config
+
+import f2.dsl.cqrs.exception.F2Exception
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import tools.jackson.module.kotlin.KotlinInvalidNullException
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
+
+class F2ExceptionHandlerTest {
+
+    private val handler = F2ExceptionHandler()
+
+    data class Sample(val name: String)
+
+    @Test
+    fun `handleF2Exception should map error code to http status`() {
+        val exception = F2Exception(message = "User not found", id = "error-id", code = 404)
+
+        val response = handler.handleF2Exception(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body!!["id"]).isEqualTo("error-id")
+        assertThat(response.body!!["code"]).isEqualTo(404)
+        assertThat(response.body!!["message"]).isEqualTo("User not found")
+        assertThat(response.body!!["timestamp"]).isNotNull
+    }
+
+    @Test
+    fun `handleF2Exception should default to internal server error for unknown code`() {
+        val exception = F2Exception(message = "Broken", code = 999)
+
+        val response = handler.handleF2Exception(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    @Test
+    fun `handleKotlinNullException should return bad request with missing parameter message`() {
+        val exception = kotlinInvalidNullException()
+
+        val response = handler.handleKotlinNullException(exception)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body!!["code"]).isEqualTo(400)
+        assertThat(response.body!!["message"]).isEqualTo("Missing parameter `name`")
+        assertThat(response.body!!["id"]).isNotNull
+        assertThat(response.body!!["timestamp"]).isNotNull
+    }
+
+    private fun kotlinInvalidNullException(): KotlinInvalidNullException {
+        var exception: KotlinInvalidNullException? = null
+        assertThatThrownBy {
+            jacksonObjectMapper().readValue<Sample>("""{"name":null}""")
+        }.isInstanceOf(KotlinInvalidNullException::class.java)
+            .satisfies({ thrown -> exception = thrown as KotlinInvalidNullException })
+        return exception!!
+    }
+}

--- a/f2-spring/exception/f2-spring-boot-exception-http-webflux/src/test/kotlin/f2/spring/exception/config/F2ErrorAttributesTest.kt
+++ b/f2-spring/exception/f2-spring-boot-exception-http-webflux/src/test/kotlin/f2/spring/exception/config/F2ErrorAttributesTest.kt
@@ -1,0 +1,63 @@
+package f2.spring.exception.config
+
+import f2.dsl.cqrs.exception.F2Exception
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerRequest
+
+class F2ErrorAttributesTest {
+
+    private val errorAttributes = F2ErrorAttributes()
+
+    private fun serverRequest(exception: Throwable): ServerRequest {
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/test"))
+        errorAttributes.storeErrorInformation(exception, exchange)
+        return ServerRequest.create(exchange, HandlerStrategies.withDefaults().messageReaders())
+    }
+
+    @Test
+    fun `should enrich attributes with f2 error fields for F2Exception`() {
+        val exception = F2Exception(message = "Something broke", id = "error-id", code = 404)
+
+        val attributes = errorAttributes.getErrorAttributes(
+            serverRequest(exception),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["id"]).isEqualTo("error-id")
+        assertThat(attributes["code"]).isEqualTo(404)
+        assertThat(attributes["message"]).isEqualTo("Something broke")
+        assertThat(attributes["timestamp"]).isNotNull
+    }
+
+    @Test
+    fun `should enrich attributes when F2Exception is the cause`() {
+        val cause = F2Exception(message = "Nested failure", id = "cause-id", code = 409)
+        val exception = IllegalStateException("wrapper", cause)
+
+        val attributes = errorAttributes.getErrorAttributes(
+            serverRequest(exception),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["id"]).isEqualTo("cause-id")
+        assertThat(attributes["code"]).isEqualTo(409)
+        assertThat(attributes["message"]).isEqualTo("Nested failure")
+    }
+
+    @Test
+    fun `should keep default attributes for non f2 exceptions`() {
+        val attributes = errorAttributes.getErrorAttributes(
+            serverRequest(IllegalStateException("unexpected")),
+            ErrorAttributeOptions.defaults()
+        )
+
+        assertThat(attributes["code"]).isNull()
+        assertThat(attributes["id"]).isNull()
+        assertThat(attributes["status"]).isEqualTo(500)
+    }
+}


### PR DESCRIPTION
Addresses the failing quality gate (new-code coverage 77.8% < 80%, duplication 8.9% > 3%). No open issues/hotspots existed.

**Coverage — ~65 new tests, all green locally:**
- `auth-commons` (19): AuthenticationProvider (reactor security context, claims, tenant, roles), PermissionEvaluator
- `auth` (16): WebSecurityConfig filter chains exercised end-to-end via `WebFilterChainProxy` + `MockServerWebExchange` (401, PermitAll/RolesAllowed, JWT authorities converter), TrustedIssuerJwtAuthenticationManagerResolver, F2TrustedIssuersConfig
- `auth-tenant` (10): WebSecurityConfig chains, tenant issuer resolver (base-uri trust, caching, converters)
- `auth-keycloak` (6), `exception-http-mvc` (6), `exception-http-webflux` (+3), `f2-feature-version` (4), `f2-feature-catalog` (3)

No Spring context or live Keycloak required. Only build change: `spring.test` bundle (+webflux starter in auth modules) as testImplementation.

**Duplication:**
- `f2-bdd`: extracted shared `LambdaStepsBase`; List/Single step bases go 39→~8 lines each. Both cucumber suites (62 scenarios each) pass.
- auth↔auth-tenant AuthenticationProvider dup: already fixed on main (auth-commons extraction) — stale analysis.
- Sample apps mvc↔webflux: accepted duplication (intentionally standalone samples).

Detekt clean on all touched modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared support for Cucumber lambda steps with single-value and list-based inputs and outputs.
  * Improved reusable step execution and consumed-item handling.

* **Bug Fixes**
  * Strengthened authentication, authorization, trusted-issuer validation, and security filter behavior.
  * Improved HTTP error responses, including exception details and invalid request handling.

* **Tests**
  * Expanded coverage for catalog and version configuration, security, issuer resolution, permissions, JWT roles, and HTTP error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->