### PR TITLE
refactor: use suspend test functions instead of runBlocking/runTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: clean lint build test publish promote
+.PHONY: clean lint build test check publish promote
 
 clean:
 	@make -f infra/make/libs.mk clean
@@ -16,6 +16,9 @@ test-pre:
 
 test:
 	@make -f infra/make/libs.mk test
+
+check:
+	@make -f infra/make/libs.mk check
 
 stage:
 	@make -f infra/make/libs.mk stage

--- a/f2-bdd/f2-bdd-spring-autoconfigure/build.gradle.kts
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
 	api(project(":f2-dsl:f2-dsl-function"))
 	api(libs.bundles.spring.cloud.function)
 	api(libs.bundles.spring.test)
+
+	implementation(libs.kotlinx.coroutines.core)
 }

--- a/f2-bdd/f2-bdd-spring-lambda/build.gradle.kts
+++ b/f2-bdd/f2-bdd-spring-lambda/build.gradle.kts
@@ -10,4 +10,7 @@ dependencies {
 	api(project(":f2-dsl:f2-dsl-cqrs"))
 	api(libs.bundles.spring.cloud.function)
 	api(libs.bundles.spring.test)
+
+	implementation(libs.kotlinx.coroutines.core)
+	implementation(libs.kotlinx.serialization.core)
 }

--- a/f2-client/f2-client-domain/build.gradle.kts
+++ b/f2-client/f2-client-domain/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 }
 
 dependencies {
-
+    commonMainApi(libs.kotlinx.serialization.core)
 }

--- a/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     commonMainApi(project(":f2-client:f2-client-core"))
     commonMainApi(project(":f2-dsl:f2-dsl-cqrs"))
 
+    commonMainApi(libs.kotlinx.serialization.json)
+
     commonMainApi(libs.ktor.client.core)
     commonMainApi(libs.ktor.client.auth)
 

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/build.gradle.kts
@@ -10,6 +10,9 @@ dependencies {
     commonMainApi(project(":f2-dsl:f2-dsl-cqrs"))
     commonMainApi(project(":f2-client:f2-client-ktor:f2-client-ktor-common"))
 
+    commonMainApi(libs.kotlinx.coroutines.core)
+    commonMainApi(libs.kotlinx.serialization.json)
+
     commonMainApi(libs.ktor.client.core)
     commonMainApi(libs.ktor.client.auth)
 

--- a/f2-dsl/f2-dsl-cqrs/build.gradle.kts
+++ b/f2-dsl/f2-dsl-cqrs/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+    commonMainApi(libs.kotlinx.coroutines.core)
+    commonMainApi(libs.kotlinx.serialization.core)
+
     jvmMainImplementation(libs.bundles.spring.data.commons)
 
     jvmTestImplementation(libs.bundles.test.junit)

--- a/f2-dsl/f2-dsl-function/build.gradle.kts
+++ b/f2-dsl/f2-dsl-function/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 dependencies {
     commonMainApi(project(":f2-dsl:f2-dsl-cqrs"))
 
+    commonMainApi(libs.kotlinx.coroutines.core)
+    commonMainApi(libs.kotlinx.serialization.core)
+
     jvmTestImplementation(libs.bundles.test.junit)
 
 }

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/build.gradle.kts
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     api(project(":f2-dsl:f2-dsl-cqrs"))
     api(project(":f2-dsl:f2-dsl-event"))
 
+    implementation(libs.kotlinx.coroutines.core)
+
     implementation(libs.spring.boot.starter.webflux)
     implementation(libs.spring.boot.autoconfigure)
 

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.reactor)
+
     api(libs.spring.boot.starter.security)
     api(libs.bundles.spring.oauth2)
 

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProviderTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/AuthenticationProviderTest.kt
@@ -1,7 +1,6 @@
 package io.komune.f2.spring.boot.auth
 
 import kotlinx.coroutines.reactor.asCoroutineContext
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -33,22 +32,22 @@ class AuthenticationProviderTest {
         roles.map { role -> SimpleGrantedAuthority("$ROLE_PREFIX$role") }
     )
 
-    private fun <T> withSecurityContext(
+    private suspend fun <T> withSecurityContext(
         authentication: JwtAuthenticationToken,
         block: suspend () -> T
-    ): T = runBlocking {
+    ): T {
         val securityContext: SecurityContext = SecurityContextImpl(authentication)
         val reactorContext = Context.of(
             SecurityContext::class.java,
             Mono.just(securityContext)
         )
-        withContext(reactorContext.asCoroutineContext()) {
+        return withContext(reactorContext.asCoroutineContext()) {
             block()
         }
     }
 
     @Test
-    fun `getSecurityContext should return null without reactor context`() = runBlocking<Unit> {
+    suspend fun `getSecurityContext should return null without reactor context`() {
         assertThat(AuthenticationProvider.getSecurityContext()).isNull()
         assertThat(AuthenticationProvider.getAuthentication()).isNull()
         assertThat(AuthenticationProvider.getPrincipal()).isNull()
@@ -59,7 +58,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getSecurityContext should return context from coroutine reactor context`() {
+    suspend fun `getSecurityContext should return context from coroutine reactor context`() {
         val securityContext = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getSecurityContext()
         }
@@ -68,7 +67,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getAuthentication should return the jwt authentication token`() {
+    suspend fun `getAuthentication should return the jwt authentication token`() {
         val authentication = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getAuthentication()
         }
@@ -77,7 +76,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getPrincipal should return the jwt`() {
+    suspend fun `getPrincipal should return the jwt`() {
         val principal = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getPrincipal()
         }
@@ -86,7 +85,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getOrganizationId should return memberOf claim`() {
+    suspend fun `getOrganizationId should return memberOf claim`() {
         val organizationId = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getOrganizationId()
         }
@@ -94,7 +93,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getIssuer should return issuer claim`() {
+    suspend fun `getIssuer should return issuer claim`() {
         val issuer = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getIssuer()
         }
@@ -102,7 +101,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getClientId should return azp claim`() {
+    suspend fun `getClientId should return azp claim`() {
         val clientId = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getClientId()
         }
@@ -110,7 +109,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getTenant should return last segment of issuer`() {
+    suspend fun `getTenant should return last segment of issuer`() {
         val tenant = withSecurityContext(authentication(jwt())) {
             AuthenticationProvider.getTenant()
         }
@@ -118,7 +117,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `getTenant should return null when issuer ends with slash`() {
+    suspend fun `getTenant should return null when issuer ends with slash`() {
         val tenant = withSecurityContext(authentication(jwt(issuer = "http://localhost:8080/"))) {
             AuthenticationProvider.getTenant()
         }
@@ -126,7 +125,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `hasRole should return true when authority is present`() {
+    suspend fun `hasRole should return true when authority is present`() {
         val hasRole = withSecurityContext(authentication(jwt(), "admin")) {
             AuthenticationProvider.hasRole("admin")
         }
@@ -134,7 +133,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `hasRole should return false when authority is missing`() {
+    suspend fun `hasRole should return false when authority is missing`() {
         val hasRole = withSecurityContext(authentication(jwt(), "user")) {
             AuthenticationProvider.hasRole("admin")
         }
@@ -142,7 +141,7 @@ class AuthenticationProviderTest {
     }
 
     @Test
-    fun `hasRole should return false without authentication`() = runBlocking<Unit> {
+    suspend fun `hasRole should return false without authentication`() {
         assertThat(AuthenticationProvider.hasRole("admin")).isFalse()
     }
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluatorTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-commons/src/test/kotlin/io/komune/f2/spring/boot/auth/PermissionEvaluatorTest.kt
@@ -1,7 +1,6 @@
 package io.komune.f2.spring.boot.auth
 
 import kotlinx.coroutines.reactor.asCoroutineContext
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -22,10 +21,10 @@ class PermissionEvaluatorTest {
         .claim(ORGANIZATION_ID_CLAIM_NAME, "organization-1")
         .build()
 
-    private fun <T> withAuthentication(
+    private suspend fun <T> withAuthentication(
         vararg roles: String,
         block: suspend () -> T
-    ): T = runBlocking {
+    ): T {
         val authentication = JwtAuthenticationToken(
             jwt(),
             roles.map { role -> SimpleGrantedAuthority("$ROLE_PREFIX$role") }
@@ -35,13 +34,13 @@ class PermissionEvaluatorTest {
             SecurityContext::class.java,
             Mono.just(securityContext)
         )
-        withContext(reactorContext.asCoroutineContext()) {
+        return withContext(reactorContext.asCoroutineContext()) {
             block()
         }
     }
 
     @Test
-    fun `isSuperAdmin should return true with super_admin role`() {
+    suspend fun `isSuperAdmin should return true with super_admin role`() {
         val isSuperAdmin = withAuthentication(SUPER_ADMIN_ROLE) {
             permissionEvaluator.isSuperAdmin()
         }
@@ -49,7 +48,7 @@ class PermissionEvaluatorTest {
     }
 
     @Test
-    fun `isSuperAdmin should return false without super_admin role`() {
+    suspend fun `isSuperAdmin should return false without super_admin role`() {
         val isSuperAdmin = withAuthentication("user") {
             permissionEvaluator.isSuperAdmin()
         }
@@ -57,17 +56,17 @@ class PermissionEvaluatorTest {
     }
 
     @Test
-    fun `isSuperAdmin should return false without authentication`() = runBlocking<Unit> {
+    suspend fun `isSuperAdmin should return false without authentication`() {
         assertThat(permissionEvaluator.isSuperAdmin()).isFalse()
     }
 
     @Test
-    fun `checkOrganizationId should return false for null organizationId`() = runBlocking<Unit> {
+    suspend fun `checkOrganizationId should return false for null organizationId`() {
         assertThat(permissionEvaluator.checkOrganizationId(null)).isFalse()
     }
 
     @Test
-    fun `checkOrganizationId should return true when it matches the authenticated organization`() {
+    suspend fun `checkOrganizationId should return true when it matches the authenticated organization`() {
         val checked = withAuthentication("user") {
             permissionEvaluator.checkOrganizationId("organization-1")
         }
@@ -75,7 +74,7 @@ class PermissionEvaluatorTest {
     }
 
     @Test
-    fun `checkOrganizationId should return false when it does not match`() {
+    suspend fun `checkOrganizationId should return false when it does not match`() {
         val checked = withAuthentication("user") {
             permissionEvaluator.checkOrganizationId("organization-2")
         }
@@ -83,7 +82,7 @@ class PermissionEvaluatorTest {
     }
 
     @Test
-    fun `checkOrganizationId should return false without authentication`() = runBlocking<Unit> {
+    suspend fun `checkOrganizationId should return false without authentication`() {
         assertThat(permissionEvaluator.checkOrganizationId("organization-1")).isFalse()
     }
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
@@ -7,5 +7,7 @@ plugins {
 dependencies {
     api(project(":f2-spring:auth:f2-spring-boot-starter-auth"))
 
+    implementation(libs.kotlinx.coroutines.core)
+
     testImplementation(libs.bundles.spring.test)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigResolverTest.kt
@@ -39,19 +39,19 @@ class KeycloakConfigResolverTest {
     }
 
     @Test
-    fun `getKeycloakConfig should return first config for null name`() = runBlocking<Unit> {
+    suspend fun `getKeycloakConfig should return first config for null name`() {
         val config = resolver.getKeycloakConfig(null)
         assertThat(config.realm).isEqualTo("master")
     }
 
     @Test
-    fun `getKeycloakConfig should return first config for blank name`() = runBlocking<Unit> {
+    suspend fun `getKeycloakConfig should return first config for blank name`() {
         val config = resolver.getKeycloakConfig("")
         assertThat(config.realm).isEqualTo("master")
     }
 
     @Test
-    fun `getKeycloakConfig should return config matching the name`() = runBlocking<Unit> {
+    suspend fun `getKeycloakConfig should return config matching the name`() {
         val config = resolver.getKeycloakConfig("second")
         assertThat(config.realm).isEqualTo("tenant")
     }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
     api(libs.spring.boot.starter.security)
     api(libs.bundles.spring.oauth2)
 
+    implementation(libs.reactor.core)
+
     testImplementation(libs.bundles.spring.test)
     testImplementation(libs.spring.boot.starter.webflux)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.spring.boot.starter.security)
     api(libs.bundles.spring.oauth2)
 
+    implementation(libs.reactor.core)
     implementation(libs.spring.boot.autoconfigure)
 
     testImplementation(libs.bundles.spring.test)

--- a/f2-spring/exception/f2-spring-boot-exception-http/build.gradle.kts
+++ b/f2-spring/exception/f2-spring-boot-exception-http/build.gradle.kts
@@ -7,4 +7,6 @@ dependencies {
     api(project(":f2-dsl:f2-dsl-cqrs"))
     implementation(libs.spring.web)
     implementation(libs.jackson.module.kotlin)
+
+    testImplementation(libs.bundles.test.junit)
 }

--- a/f2-spring/function/f2-spring-boot-starter-function/build.gradle.kts
+++ b/f2-spring/function/f2-spring-boot-starter-function/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(project(":f2-dsl:f2-dsl-function"))
 
     api(libs.bundles.coroutines)
+    api(libs.kotlinx.serialization.json)
     api(libs.bundles.spring.cloud.function)
 
     testImplementation(project(":f2-bdd:f2-bdd-spring-lambda"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,8 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor" }
 kotlinx-coroutines-reactive = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactive" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test" }
+kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json" }
 
 # Spring Boot
 spring-boot-autoconfigure = { group = "org.springframework.boot", name = "spring-boot-autoconfigure" }
@@ -110,6 +112,9 @@ spring-cloud-function-kotlin = { group = "org.springframework.cloud", name = "sp
 spring-cloud-function-web = { group = "org.springframework.cloud", name = "spring-cloud-function-web" }
 spring-cloud-starter-function-webflux = { group = "org.springframework.cloud", name = "spring-cloud-starter-function-webflux" }
 spring-cloud-starter-function-web = { group = "org.springframework.cloud", name = "spring-cloud-starter-function-web" }
+
+# Reactor
+reactor-core = { group = "io.projectreactor", name = "reactor-core" }
 
 # Jakarta
 jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persistence-api" }

--- a/infra/make/libs.mk
+++ b/infra/make/libs.mk
@@ -1,6 +1,6 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: clean lint build test publish promote version
+.PHONY: clean lint build test check publish promote version
 
 clean:
 	./gradlew clean
@@ -13,6 +13,9 @@ build:
 
 test:
 	./gradlew test
+
+check:
+	VERSION=$(VERSION) ./gradlew sonar
 
 stage:
 	VERSION=$(VERSION) ./gradlew stage

--- a/sample/f2-sample-http-mvc/build.gradle.kts
+++ b/sample/f2-sample-http-mvc/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     implementation(project(":f2-spring:function:f2-spring-boot-starter-function-http-mvc"))
     implementation(project(":f2-spring:openapi:f2-spring-boot-openapi-mvc"))
+
+    implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.bundles.spring.test)
 }
 

--- a/sample/f2-sample-http/build.gradle.kts
+++ b/sample/f2-sample-http/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":f2-spring:function:f2-spring-boot-starter-function-http-webflux"))
     implementation(project(":f2-spring:openapi:f2-spring-boot-openapi-webflux"))
 
+    implementation(libs.kotlinx.coroutines.core)
+
     testImplementation(libs.bundles.spring.test)
 }
 


### PR DESCRIPTION
Converts JUnit test methods to `@Test suspend fun` (native JUnit Jupiter 6 support), replacing `runBlocking`/`runTest` wrappers — 3 files, 22 tests (AuthenticationProviderTest, PermissionEvaluatorTest, KeycloakConfigResolverTest), including their suspend helper functions.

Kept as-is: `runBlocking` inside `assertThatThrownBy { }` lambdas (AssertJ's ThrowingCallable is not suspend), a nested consumer-lambda usage in CoroutinesUtilsTest, and Cucumber step definitions.

All 4 affected test classes run green with skipped=0 verified via test-result XMLs (no silent skips).

Follow-up of #113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated authentication, permission, and Keycloak configuration tests to use coroutine-based execution.
  * Preserved existing security-context handling, assertions, and expected behavior.
  * Simplified asynchronous test flows by removing blocking wrappers.

* **Chores**
  * Added a build check target for running Sonar analysis with the current version.
  * Improved coroutine, serialization, and reactive support across supported modules.
  * Added testing support for the exception-handling module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->