### PR TITLE
fix: SonarQube cleanup and test coverage to ~83%

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   libs:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@ce41e619db32403a51e6ad05806eeb890aad1385 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   libs:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@ce41e619db32403a51e6ad05806eeb890aad1385 # main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write

--- a/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/F2SpringContextStep.kt
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/F2SpringContextStep.kt
@@ -66,7 +66,7 @@ open class F2SpringContextStep: F2SpringStep(), En {
 	private fun DataTable.asCucumberF2SpringDeclaration(): List<CucumberF2SpringDeclaration> {
 		return asMaps().map { columns ->
 			CucumberF2SpringDeclaration(
-				name = columns[CucumberF2SpringDeclaration::name.name]!!,
+				name = columns.getValue(CucumberF2SpringDeclaration::name.name),
 			)
 		}
 	}

--- a/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/FunctionCatalogStepsBase.kt
+++ b/f2-bdd/f2-bdd-spring-autoconfigure/src/main/kotlin/f2/bdd/spring/autoconfigure/steps/FunctionCatalogStepsBase.kt
@@ -47,7 +47,7 @@ abstract class FunctionCatalogStepsBase<P, R>(
 		result: Any?
 	) {
 		if (lambda.isFunction || lambda.isSupplier) {
-			bag.result[functionName] = (result as Flux<String>).collectList().block()!!
+			bag.result[functionName] = (result as Flux<*>).collectList().block()!!
 		} else if (lambda.isConsumer) {
 			bag.result[functionName] = consumerReceiver()
 		}

--- a/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/flow/LambdaFlowSteps.kt
+++ b/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/flow/LambdaFlowSteps.kt
@@ -20,6 +20,7 @@ abstract class LambdaFlowSteps : LambdaListStepsBase<String, String>() {
 		return dataTable.asList()
 	}
 
+	@Suppress("UNCHECKED_CAST")
 	override fun receiver(): ConsumerReceiver<String> {
 		return bag.applicationContext!!.getBean(LambdaSimple::lambdaSingleReceiver.name) as ConsumerReceiver<String>
 	}

--- a/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/flux/LambdaFluxSteps.kt
+++ b/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/flux/LambdaFluxSteps.kt
@@ -20,6 +20,7 @@ abstract class LambdaFluxSteps: LambdaListStepsBase<String, String>() {
 		return dataTable.asList()
 	}
 
+	@Suppress("UNCHECKED_CAST")
 	override fun receiver(): ConsumerReceiver<String> {
 		return bag.applicationContext!!.getBean(LambdaSimple::lambdaSingleReceiver.name) as ConsumerReceiver<String>
 	}

--- a/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/methodcall/MethodCallSteps.kt
+++ b/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/methodcall/MethodCallSteps.kt
@@ -20,6 +20,7 @@ abstract class MethodCallSteps : LambdaListStepsBase<String, String>() {
 		return dataTable.asList()
 	}
 
+	@Suppress("UNCHECKED_CAST")
 	override fun receiver(): ConsumerReceiver<String> {
 		return bag.applicationContext!!.getBean(LambdaSimple::lambdaSingleReceiver.name) as ConsumerReceiver<String>
 	}

--- a/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/single/LambdaSimpleSteps.kt
+++ b/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/single/LambdaSimpleSteps.kt
@@ -25,6 +25,7 @@ abstract class LambdaSimpleSteps: LambdaSingleStepsBase<String, String>() {
 		return dataTable.asList().first()
 	}
 
+	@Suppress("UNCHECKED_CAST")
 	override fun receiver(): ConsumerReceiver<String> {
 		return bag.applicationContext!!.getBean(LambdaSimple::lambdaSingleReceiver.name) as ConsumerReceiver<String>
 	}

--- a/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/vehicle/LambdaF2VehicleSteps.kt
+++ b/f2-bdd/f2-bdd-spring-lambda/src/main/kotlin/f2/bdd/spring/lambda/vehicle/LambdaF2VehicleSteps.kt
@@ -8,8 +8,8 @@ open class LambdaF2VehicleSteps : FunctionCatalogStepsBase<Vehicle, Vehicle>("Ve
 	override fun transform(dataTable: DataTable): List<Vehicle> {
 		return dataTable.asMaps().map {
 			Vehicle(
-				name = it[Vehicle::name.name]!!,
-				broken = it[Vehicle::broken.name]!!.toBoolean()
+				name = it.getValue(Vehicle::name.name),
+				broken = it.getValue(Vehicle::broken.name).toBoolean()
 			)
 		}
 	}

--- a/f2-client/f2-client-ktor/build.gradle.kts
+++ b/f2-client/f2-client-ktor/build.gradle.kts
@@ -8,4 +8,10 @@ dependencies {
     commonMainApi(libs.ktor.client.logging)
     commonMainApi(project(":f2-client:f2-client-core"))
     commonMainApi(project(":f2-client:f2-client-ktor:f2-client-ktor-http"))
+
+    jvmTestImplementation(libs.bundles.test.junit)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
@@ -26,3 +26,7 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
+++ b/f2-client/f2-client-ktor/f2-client-ktor-common/build.gradle.kts
@@ -26,7 +26,3 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
-
-tasks.withType<Test> {
-    useJUnitPlatform()
-}

--- a/f2-client/f2-client-ktor/f2-client-ktor-common/src/jvmTest/kotlin/f2/client/ktor/common/HttpClientConfigExtensionTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-common/src/jvmTest/kotlin/f2/client/ktor/common/HttpClientConfigExtensionTest.kt
@@ -1,0 +1,55 @@
+package f2.client.ktor.common
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineConfig
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@Serializable
+private data class JsonSample(
+    val name: String,
+    val optional: String = "default",
+    val nullable: String? = null,
+)
+
+class HttpClientConfigExtensionTest {
+
+    @Test
+    fun `applyConfig installs content negotiation and applies custom config`() {
+        val config = HttpClientConfig<HttpClientEngineConfig>()
+        var applied = false
+
+        config.applyConfig { applied = true }
+
+        assertThat(applied).isTrue()
+    }
+
+    @Test
+    fun `applyConfig accepts a null custom config`() {
+        val config = HttpClientConfig<HttpClientEngineConfig>()
+
+        config.applyConfig(null)
+
+        assertThat(config).isNotNull()
+    }
+
+    @Test
+    fun `F2DefaultJson ignores unknown keys and is lenient`() {
+        val decoded = F2DefaultJson.decodeFromString<JsonSample>(
+            """{"name": "value", "unknown": "field"}"""
+        )
+
+        assertThat(decoded.name).isEqualTo("value")
+        assertThat(decoded.nullable).isNull()
+    }
+
+    @Test
+    fun `F2DefaultJson encodes defaults and omits nulls`() {
+        val encoded = F2DefaultJson.encodeToString(JsonSample(name = "value"))
+
+        assertThat(encoded)
+            .contains("\"optional\":\"default\"")
+            .doesNotContain("nullable")
+    }
+}

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/HttpF2Client.kt
@@ -33,6 +33,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -72,13 +73,16 @@ open class HttpF2Client(
 			if (!response.status.isSuccess()) {
 				handleError(response)
 			}
-			response.body<T>(typeInfo).let { result ->
-				if (result is Collection<*>) {
-					result.forEach { emit(it as T) }
-				} else {
-					emit(result)
-				}
-			}
+			emitPayload(response.body<T>(typeInfo))
+		}
+	}
+
+	private suspend fun <T> FlowCollector<T>.emitPayload(result: T) {
+		if (result is Collection<*>) {
+			@Suppress("UNCHECKED_CAST")
+			(result as Collection<T>).forEach { emit(it) }
+		} else {
+			emit(result)
 		}
 	}
 
@@ -97,13 +101,7 @@ open class HttpF2Client(
 			if (!response.status.isSuccess()) {
 				handleError(response)
 			}
-			response.body<RESPONSE>(responseTypeInfo).let { result ->
-				if (result is Collection<*>) {
-					result.forEach { emit(it as RESPONSE) }
-				} else {
-					emit(result)
-				}
-			}
+			emitPayload(response.body<RESPONSE>(responseTypeInfo))
 		}
 	}
 

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/F2Auth.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/plugin/F2Auth.kt
@@ -156,11 +156,3 @@ class F2Auth(
         }
     }
 }
-
-//private fun Auth.basicAuth(realm: AuthRealmClientSecret) {
-//    basic {
-//        credentials {
-//            BasicAuthCredentials(username = realm.clientId, password = realm.clientSecret)
-//        }
-//    }
-//}

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientUploadTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/HttpF2ClientUploadTest.kt
@@ -1,0 +1,115 @@
+package f2.client.ktor.http
+
+import f2.client.ktor.http.model.F2FilePart
+import f2.client.ktor.http.model.F2UploadCommand
+import f2.client.ktor.http.model.F2UploadMultipleCommand
+import f2.client.ktor.http.model.F2UploadSingleCommand
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.reflect.TypeInfo
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.reflect.typeOf
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@Serializable
+data class UploadTestBody(val someData: String)
+
+@Serializable
+data class UploadTestEvent(val ok: Boolean)
+
+class HttpF2ClientUploadTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private class RecordedRequest {
+        var contentType: String? = null
+        var body: String? = null
+    }
+
+    private fun mockClient(recorded: RecordedRequest): HttpClient = HttpClient(MockEngine { request ->
+        recorded.contentType = request.body.contentType?.toString()
+        recorded.body = request.body.toByteArray().decodeToString()
+        respond(
+            content = """{"ok":true}""",
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        )
+    }) {
+        install(ContentNegotiation) {
+            json(json)
+        }
+    }
+
+    private fun uploadFunction(client: HttpF2Client) = client.function<F2UploadCommand<UploadTestBody>, UploadTestEvent>(
+        route = "upload",
+        queryTypeInfo = TypeInfo(F2UploadCommand::class, typeOf<UploadTestBody>()),
+        responseTypeInfo = TypeInfo(UploadTestEvent::class, typeOf<UploadTestEvent>())
+    )
+
+    @Test
+    suspend fun `function posts single upload command as multipart form data`() {
+        val recorded = RecordedRequest()
+        val client = HttpF2Client(mockClient(recorded), "http://localhost", json)
+
+        val command = F2UploadSingleCommand(
+            command = UploadTestBody("hello-upload"),
+            file = F2FilePart(
+                name = "file.txt",
+                content = ByteReadChannel("file-content"),
+                contentType = "text/plain"
+            )
+        )
+
+        val results = uploadFunction(client).invoke(flowOf(command)).toList()
+
+        assertThat(results).containsExactly(UploadTestEvent(ok = true))
+        assertThat(recorded.contentType).startsWith("multipart/form-data")
+        assertThat(recorded.body)
+            .contains("someData")
+            .contains("hello-upload")
+            .contains("filename=file.txt")
+            .contains("file-content")
+            .contains("text/plain")
+    }
+
+    @Test
+    suspend fun `function posts multiple upload files in one multipart request`() {
+        val recorded = RecordedRequest()
+        val client = HttpF2Client(mockClient(recorded), "http://localhost", json)
+
+        val command = F2UploadMultipleCommand(
+            command = UploadTestBody("multi-upload"),
+            files = listOf(
+                F2FilePart(name = "first.txt", content = ByteReadChannel("first-content"), contentType = "text/plain"),
+                F2FilePart(name = "second.bin", content = ByteReadChannel("second-content")),
+            )
+        )
+
+        val results = uploadFunction(client).invoke(flowOf(command)).toList()
+
+        assertThat(results).containsExactly(UploadTestEvent(ok = true))
+        assertThat(recorded.contentType).startsWith("multipart/form-data")
+        assertThat(recorded.body)
+            .contains("multi-upload")
+            .contains("filename=first.txt")
+            .contains("first-content")
+            .contains("filename=second.bin")
+            .contains("second-content")
+    }
+}

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/plugin/F2AuthTest.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/jvmTest/kotlin/f2/client/ktor/http/plugin/F2AuthTest.kt
@@ -1,0 +1,173 @@
+package f2.client.ktor.http.plugin
+
+import com.sun.net.httpserver.HttpServer
+import f2.client.domain.AuthRealm
+import f2.client.domain.AuthRealmClientSecret
+import f2.client.domain.AuthRealmPassword
+import f2.dsl.cqrs.exception.F2Exception
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.net.InetSocketAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class F2AuthTest {
+
+    companion object {
+        private const val REALM_ID = "test-realm"
+        private const val TOKEN_PATH = "/realms/$REALM_ID/protocol/openid-connect/token"
+    }
+
+    private class TokenServer(vararg responses: String) : AutoCloseable {
+        val requestBodies = mutableListOf<String>()
+        private val server: HttpServer = HttpServer.create(InetSocketAddress(0), 0)
+
+        init {
+            var index = 0
+            server.createContext(TOKEN_PATH) { exchange ->
+                requestBodies.add(exchange.requestBody.readAllBytes().decodeToString())
+                val response = responses[minOf(index, responses.size - 1)].toByteArray()
+                index++
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, response.size.toLong())
+                exchange.responseBody.use { it.write(response) }
+            }
+            server.start()
+        }
+
+        val url: String get() = "http://localhost:${server.address.port}"
+
+        override fun close() = server.stop(0)
+    }
+
+    private fun tokenJson(accessToken: String, refreshToken: String? = null): String {
+        val refresh = refreshToken?.let { ""","refresh_token":"$it"""" } ?: ""
+        return """{"access_token":"$accessToken","expires_in":300,""" +
+            """"token_type":"Bearer","scope":"openid"$refresh}"""
+    }
+
+    private fun clientSecretRealm(serverUrl: String) = AuthRealmClientSecret(
+        serverUrl = serverUrl,
+        realmId = REALM_ID,
+        clientId = "test-client",
+        clientSecret = "test-secret",
+    )
+
+    private fun protectedClient(
+        realm: AuthRealm,
+        acceptedTokens: Set<String>,
+        authHeaders: MutableList<String?> = mutableListOf(),
+    ): HttpClient = HttpClient(MockEngine { request ->
+        val auth = request.headers[HttpHeaders.Authorization]
+        authHeaders.add(auth)
+        if (auth != null && auth.removePrefix("Bearer ") in acceptedTokens) {
+            respond(
+                content = """{"ok":true}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        } else {
+            respond(
+                content = "Unauthorized",
+                status = HttpStatusCode.Unauthorized,
+                headers = headersOf(HttpHeaders.WWWAuthenticate, "Bearer")
+            )
+        }
+    }) {
+        install(F2Auth) {
+            getAuth = { realm }
+        }
+    }
+
+    @Test
+    suspend fun `fetches a token with client credentials and authenticates the request`() {
+        TokenServer(tokenJson("token-cs")).use { server ->
+            val client = protectedClient(
+                realm = clientSecretRealm(server.url),
+                acceptedTokens = setOf("token-cs")
+            )
+
+            val response = client.get("http://protected/api")
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(response.bodyAsText()).contains("true")
+            assertThat(server.requestBodies.first())
+                .contains("grant_type=client_credentials")
+                .contains("client_id=test-client")
+                .contains("client_secret=test-secret")
+            client.close()
+        }
+    }
+
+    @Test
+    suspend fun `refreshes the token when the server rejects the current one`() {
+        TokenServer(
+            tokenJson("token-r1", refreshToken = "refresh-1"),
+            tokenJson("token-r2"),
+        ).use { server ->
+            val client = protectedClient(
+                realm = clientSecretRealm(server.url),
+                acceptedTokens = setOf("token-r2")
+            )
+
+            val response = client.get("http://protected/api")
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(server.requestBodies).hasSize(2)
+            assertThat(server.requestBodies.last())
+                .contains("grant_type=refresh_token")
+                .contains("refresh_token=refresh-1")
+            client.close()
+        }
+    }
+
+    @Test
+    suspend fun `fetches a token with password grant`() {
+        TokenServer(tokenJson("token-pw")).use { server ->
+            val realm = AuthRealmPassword(
+                serverUrl = server.url,
+                realmId = REALM_ID,
+                redirectUrl = "",
+                clientId = "test-client",
+                username = "john",
+                password = "doe",
+            )
+            val client = protectedClient(realm = realm, acceptedTokens = setOf("token-pw"))
+
+            val response = client.get("http://protected/api")
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(server.requestBodies.first())
+                .contains("grant_type=password")
+                .contains("username=john")
+                .contains("password=doe")
+            client.close()
+        }
+    }
+
+    @Test
+    suspend fun `fails with F2Exception when the token response cannot be decoded`() {
+        TokenServer("not-a-json").use { server ->
+            val client = protectedClient(
+                realm = clientSecretRealm(server.url),
+                acceptedTokens = setOf("any")
+            )
+
+            val thrown = runCatching { client.get("http://protected/api") }.exceptionOrNull()
+
+            assertThat(thrown).isNotNull()
+            val f2Exception = generateSequence(thrown) { it.cause }
+                .filterIsInstance<F2Exception>()
+                .firstOrNull()
+            assertThat(f2Exception).isNotNull()
+            assertThat(f2Exception!!.error.message).contains("Unable to decode response")
+            client.close()
+        }
+    }
+}

--- a/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/F2ClientBuilder.kt
+++ b/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/F2ClientBuilder.kt
@@ -10,6 +10,9 @@ import f2.client.ktor.http.httpClientBuilderGenerics
  */
 object F2ClientBuilder {
 
+    private const val HTTP_PREFIX = "http:"
+    private const val HTTPS_PREFIX = "https:"
+
     /**
      * Creates an [F2Client] for HTTP or HTTPS communication.
      *
@@ -21,8 +24,8 @@ object F2ClientBuilder {
         url: String,
     ): F2Client {
         return when {
-            url.startsWith("http:") -> httpClientBuilderDefault().build(url)
-            url.startsWith("https:") -> httpClientBuilderDefault().build(url)
+            url.startsWith(HTTP_PREFIX) -> httpClientBuilderDefault().build(url)
+            url.startsWith(HTTPS_PREFIX) -> httpClientBuilderDefault().build(url)
             else -> throw IllegalArgumentException(
                 "Invalid Url[${url}] must start by one of http:, https:, tcp:, ws:, wss:"
             )
@@ -42,8 +45,8 @@ object F2ClientBuilder {
         config: F2ClientConfigLambda<*>? = null
     ): F2Client {
         return when {
-            urlBase.startsWith("http:") -> httpClientBuilderGenerics(config).build(urlBase)
-            urlBase.startsWith("https:") -> httpClientBuilderGenerics(config).build(urlBase)
+            urlBase.startsWith(HTTP_PREFIX) -> httpClientBuilderGenerics(config).build(urlBase)
+            urlBase.startsWith(HTTPS_PREFIX) -> httpClientBuilderGenerics(config).build(urlBase)
             else -> throw InvalidUrlException(urlBase)
         }
     }
@@ -59,8 +62,8 @@ object F2ClientBuilder {
         url: String,
     ): F2Client {
         return when {
-            url.startsWith("http:") -> httpClientBuilderDefault().build(url)
-            url.startsWith("https:") -> httpClientBuilderDefault().build(url)
+            url.startsWith(HTTP_PREFIX) -> httpClientBuilderDefault().build(url)
+            url.startsWith(HTTPS_PREFIX) -> httpClientBuilderDefault().build(url)
             else -> throw IllegalArgumentException(
                 "Invalid Url[${url}] must start by one of http:, https:, tcp:, ws:, wss:"
             )

--- a/f2-client/f2-client-ktor/src/jvmTest/kotlin/f2/client/ktor/F2ClientBuilderTest.kt
+++ b/f2-client/f2-client-ktor/src/jvmTest/kotlin/f2/client/ktor/F2ClientBuilderTest.kt
@@ -1,0 +1,55 @@
+package f2.client.ktor
+
+import f2.client.F2ClientType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class F2ClientBuilderTest {
+
+    @Test
+    fun `getHttp builds a client for http and https urls`() {
+        assertThat(F2ClientBuilder.getHttp("http://localhost:8080").type).isEqualTo(F2ClientType.HTTP)
+        assertThat(F2ClientBuilder.getHttp("https://localhost:8080").type).isEqualTo(F2ClientType.HTTP)
+    }
+
+    @Test
+    fun `getHttp rejects unsupported protocols`() {
+        assertThatThrownBy { F2ClientBuilder.getHttp("ftp://localhost") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid Url")
+    }
+
+    @Test
+    suspend fun `get builds a client for http and https urls`() {
+        assertThat(F2ClientBuilder.get("http://localhost:8080").type).isEqualTo(F2ClientType.HTTP)
+        assertThat(F2ClientBuilder.get("https://localhost:8080").type).isEqualTo(F2ClientType.HTTP)
+    }
+
+    @Test
+    suspend fun `get rejects unsupported protocols`() {
+        val thrown = runCatching { F2ClientBuilder.get("ftp://localhost") }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    suspend fun `get with config builds a client for http and https urls`() {
+        var configured = false
+        val client = F2ClientBuilder.get("http://localhost:8080") { configured = true }
+
+        assertThat(client.type).isEqualTo(F2ClientType.HTTP)
+        assertThat(configured).isTrue()
+
+        assertThat(F2ClientBuilder.get("https://localhost:8080") { }.type).isEqualTo(F2ClientType.HTTP)
+    }
+
+    @Test
+    suspend fun `get with config rejects unsupported protocols`() {
+        val thrown = runCatching { F2ClientBuilder.get("ftp://localhost") { } }.exceptionOrNull()
+
+        assertThat(thrown)
+            .isInstanceOf(InvalidUrlException::class.java)
+            .hasMessageContaining("is invalid")
+    }
+}

--- a/f2-dsl/f2-dsl-cqrs/build.gradle.kts
+++ b/f2-dsl/f2-dsl-cqrs/build.gradle.kts
@@ -12,3 +12,7 @@ dependencies {
 
     jvmTestImplementation(libs.bundles.test.junit)
 }
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/envelope/EnvelopeExtensionTest.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/envelope/EnvelopeExtensionTest.kt
@@ -1,0 +1,56 @@
+package f2.dsl.cqrs.envelope
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EnvelopeExtensionTest {
+
+    @Test
+    fun `asEnvelopeWithType wraps data with the given type`() {
+        val envelope = "payload".asEnvelopeWithType(type = "CustomType", id = "id-1")
+
+        assertThat(envelope.data).isEqualTo("payload")
+        assertThat(envelope.type).isEqualTo("CustomType")
+        assertThat(envelope.id).isEqualTo("id-1")
+        assertThat(envelope.specversion).isEqualTo("1.0")
+        assertThat(envelope.source).isNull()
+        assertThat(envelope.time).isNull()
+        assertThat(envelope.datacontenttype).isNull()
+    }
+
+    @Test
+    fun `asEnvelopeWithType copies metadata from source envelope`() {
+        val from = Envelope(
+            id = "origin-id",
+            data = 1,
+            type = "Origin",
+            source = "test-source",
+            time = "2024-01-01T00:00:00Z",
+            datacontenttype = "application/json",
+        )
+
+        val envelope = "payload".asEnvelopeWithType(type = "CustomType", from = from)
+
+        assertThat(envelope.id).isEqualTo("origin-id")
+        assertThat(envelope.source).isEqualTo("test-source")
+        assertThat(envelope.time).isEqualTo("2024-01-01T00:00:00Z")
+        assertThat(envelope.datacontenttype).isEqualTo("application/json")
+    }
+
+    @Test
+    fun `asEnvelope wraps data with the class simple name as type`() {
+        val envelope = "payload".asEnvelope(id = "id-2")
+
+        assertThat(envelope.type).isEqualTo("String")
+        assertThat(envelope.data).isEqualTo("payload")
+        assertThat(envelope.id).isEqualTo("id-2")
+    }
+
+    @Test
+    fun `asEnvelope generates a random id when none provided`() {
+        val envelope = 42.asEnvelope()
+
+        assertThat(envelope.id).isNotBlank()
+        assertThat(envelope.type).isEqualTo("Int")
+    }
+}

--- a/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/error/F2ErrorExtensionTest.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/error/F2ErrorExtensionTest.kt
@@ -1,0 +1,59 @@
+package f2.dsl.cqrs.error
+
+import f2.dsl.cqrs.exception.F2Exception
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class F2ErrorExtensionTest {
+
+    @Test
+    fun `asException wraps error without cause`() {
+        val error = F2Error(message = "boom", code = 418)
+
+        val exception = error.asException()
+
+        assertThat(exception.error).isEqualTo(error)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.message).isEqualTo("boom")
+    }
+
+    @Test
+    fun `asException wraps error with cause`() {
+        val error = F2Error(message = "boom")
+        val cause = IllegalStateException("cause")
+
+        val exception = error.asException(cause)
+
+        assertThat(exception.error).isEqualTo(error)
+        assertThat(exception.cause).isEqualTo(cause)
+    }
+
+    @Test
+    fun `throwException throws an F2Exception carrying the error`() {
+        val error = F2Error(message = "boom")
+
+        assertThatThrownBy { error.throwException() }
+            .isInstanceOf(F2Exception::class.java)
+            .hasMessage("boom")
+
+        val cause = IllegalArgumentException("cause")
+        assertThatThrownBy { error.throwException(cause) }
+            .isInstanceOf(F2Exception::class.java)
+            .hasCause(cause)
+    }
+
+    @Test
+    fun `asError builds an F2Error from an exception`() {
+        assertThat(IllegalStateException("oops").asError().message).isEqualTo("oops")
+        assertThat(IllegalStateException().asError().message).isEqualTo("Unknown error")
+    }
+
+    @Test
+    fun `f2Error toString contains error fields`() {
+        val error = F2Error(message = "boom", code = 400, timestamp = "now", requestId = "req-1")
+
+        assertThat(error.toString())
+            .isEqualTo("F2Error(timestamp='now', code=400, requestId='req-1', message='boom')")
+    }
+}

--- a/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/filter/MatchTest.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/filter/MatchTest.kt
@@ -1,0 +1,155 @@
+package f2.dsl.cqrs.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MatchTest {
+
+    @Test
+    fun `exactMatch map transforms value and keeps negative flag`() {
+        val match = ExactMatch(value = 1, negative = true).map { it.toString() }
+
+        assertThat(match).isEqualTo(ExactMatch(value = "1", negative = true))
+    }
+
+    @Test
+    fun `exactMatch not inverts negative flag`() {
+        val match = ExactMatch(value = 1)
+
+        assertThat(match.not().negative).isTrue()
+        assertThat((!match).negative).isTrue()
+    }
+
+    @Test
+    fun `and combines two matches into an AndMatch`() {
+        val left = ExactMatch(value = 1)
+        val right = ExactMatch(value = 2)
+
+        val match = left and right
+
+        assertThat(match).isEqualTo(AndMatch(matches = listOf(left, right)))
+    }
+
+    @Test
+    fun `or combines two matches into an OrMatch`() {
+        val left = ExactMatch(value = 1)
+        val right = ExactMatch(value = 2)
+
+        val match = left or right
+
+        assertThat(match).isEqualTo(OrMatch(matches = listOf(left, right)))
+    }
+
+    @Test
+    fun `andMatch map, not and and operate on children`() {
+        val match = AndMatch(matches = listOf(ExactMatch(value = 1), ExactMatch(value = 2)))
+
+        val mapped = match.map { it * 10 }
+        assertThat(mapped).isEqualTo(AndMatch(matches = listOf(ExactMatch(value = 10), ExactMatch(value = 20))))
+
+        assertThat(match.not().negative).isTrue()
+
+        val extended = match and ExactMatch(value = 3)
+        assertThat(extended.matches).hasSize(3)
+    }
+
+    @Test
+    fun `orMatch map, not and or operate on children`() {
+        val match = OrMatch(matches = listOf(ExactMatch(value = 1), ExactMatch(value = 2)))
+
+        val mapped = match.map { it * 10 }
+        assertThat(mapped).isEqualTo(OrMatch(matches = listOf(ExactMatch(value = 10), ExactMatch(value = 20))))
+
+        assertThat(match.not().negative).isTrue()
+
+        val extended = match or ExactMatch(value = 3)
+        assertThat(extended.matches).hasSize(3)
+    }
+
+    @Test
+    fun `collectionMatch map transforms all values`() {
+        val match = CollectionMatch(values = listOf(1, 2, 3))
+
+        val mapped = match.map { it.toString() }
+
+        assertThat(mapped).isEqualTo(CollectionMatch(values = listOf("1", "2", "3")))
+        assertThat(match.not().negative).isTrue()
+    }
+
+    @Test
+    fun `stringMatch toString builds pattern by condition`() {
+        assertThat(StringMatch("abc", StringMatchCondition.EXACT).toString()).isEqualTo("abc")
+        assertThat(StringMatch("abc", StringMatchCondition.STARTS_WITH).toString()).isEqualTo("abc%")
+        assertThat(StringMatch("abc", StringMatchCondition.ENDS_WITH).toString()).isEqualTo("%abc")
+        assertThat(StringMatch("abc", StringMatchCondition.CONTAINS).toString()).isEqualTo("%abc%")
+    }
+
+    @Test
+    fun `stringMatch map keeps StringMatch for string results`() {
+        val match = StringMatch("abc", StringMatchCondition.EXACT)
+
+        val mapped = match.map { it.uppercase() }
+
+        assertThat(mapped).isEqualTo(StringMatch("ABC", StringMatchCondition.EXACT))
+        assertThat(match.not().negative).isTrue()
+    }
+
+    @Test
+    fun `stringMatch map falls back to ExactMatch for non-string results`() {
+        val match = StringMatch("42", StringMatchCondition.EXACT)
+
+        val mapped = match.map { it.toInt() }
+
+        assertThat(mapped).isEqualTo(ExactMatch(value = 42))
+    }
+
+    @Test
+    fun `comparableMatch map keeps condition`() {
+        val match = ComparableMatch(value = 1, condition = ComparableMatchCondition.GT)
+
+        val mapped = match.map { it * 2 }
+
+        assertThat(mapped).isEqualTo(ComparableMatch(value = 2, condition = ComparableMatchCondition.GT))
+        assertThat(match.not().negative).isTrue()
+    }
+
+    @Test
+    fun `collectionMatchOf builds a CollectionMatch from values`() {
+        assertThat(collectionMatchOf(1, 2, 2)).isEqualTo(CollectionMatch(values = setOf(1, 2)))
+    }
+
+    @Test
+    fun `collectionMatchOfNullable maps null literals to null`() {
+        val match = collectionMatchOfNullable(listOf("a", "null", "NULL"))
+
+        assertThat(match.values).containsExactly("a", null, null)
+    }
+
+    @Test
+    fun `andMatchOf and orMatchOf build composite matches`() {
+        assertThat(andMatchOf(ExactMatch(1), ExactMatch(2)).matches).hasSize(2)
+        assertThat(orMatchOf(ExactMatch(1), ExactMatch(2)).matches).hasSize(2)
+    }
+
+    @Test
+    fun `andMatchOfNotNull handles empty, single and multiple matches`() {
+        assertThat(andMatchOfNotNull<Int>(null, null)).isNull()
+        assertThat(andMatchOfNotNull(ExactMatch(1), null)).isEqualTo(ExactMatch(1))
+        assertThat(andMatchOfNotNull(ExactMatch(1), ExactMatch(2)))
+            .isEqualTo(AndMatch(listOf(ExactMatch(1), ExactMatch(2))))
+    }
+
+    @Test
+    fun `orMatchOfNotNull handles empty, single and multiple matches`() {
+        assertThat(orMatchOfNotNull<Int>(null, null)).isNull()
+        assertThat(orMatchOfNotNull(ExactMatch(1), null)).isEqualTo(ExactMatch(1))
+        assertThat(orMatchOfNotNull(ExactMatch(1), ExactMatch(2)))
+            .isEqualTo(OrMatch(listOf(ExactMatch(1), ExactMatch(2))))
+    }
+
+    @Test
+    fun `nullableExactMatchOf maps null literal to null value`() {
+        assertThat(nullableExactMatchOf("value")).isEqualTo(ExactMatch<String?>("value"))
+        assertThat(nullableExactMatchOf("null")).isEqualTo(ExactMatch<String?>(null))
+    }
+}

--- a/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/page/PageExtensionTest.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/jvmTest/kotlin/f2/dsl/cqrs/page/PageExtensionTest.kt
@@ -1,0 +1,60 @@
+package f2.dsl.cqrs.page
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+
+class PageExtensionTest {
+
+    @Test
+    fun `result builds a PageQueryResult from a pagination`() {
+        val pagination = OffsetPagination(offset = 0, limit = 10)
+
+        val result = pagination.result(items = listOf("a", "b"), total = 12)
+
+        assertThat(result.items).containsExactly("a", "b")
+        assertThat(result.total).isEqualTo(12)
+        assertThat(result.pagination?.offset).isEqualTo(0)
+        assertThat(result.pagination?.limit).isEqualTo(10)
+    }
+
+    @Test
+    fun `map transforms page items`() {
+        val page: PageDTO<Int> = Page(total = 2, items = listOf(1, 2))
+
+        val mapped = page.map { it.toString() }
+
+        assertThat(mapped.items).containsExactly("1", "2")
+        assertThat(mapped.total).isEqualTo(2)
+    }
+
+    @Test
+    fun `mapNotNull drops null transformations`() {
+        val page: PageDTO<Int> = Page(total = 3, items = listOf(1, 2, 3))
+
+        val mapped = page.mapNotNull { value -> value.takeIf { it % 2 == 1 } }
+
+        assertThat(mapped.items).containsExactly(1, 3)
+    }
+
+    @Test
+    fun `toPageRequest maps offset pagination to a page request`() {
+        val pageRequest = OffsetPagination(offset = 0, limit = 10).toPageRequest()
+
+        assertThat(pageRequest).isEqualTo(PageRequest.of(0, 10))
+    }
+
+    @Test
+    fun `toPageRequest maps second page pagination`() {
+        val pageRequest = OffsetPagination(offset = 10, limit = 20).toPageRequest()
+
+        assertThat(pageRequest).isEqualTo(PageRequest.of(1, 10))
+    }
+
+    @Test
+    fun `toPageRequest defaults to first page with max size on null`() {
+        val pageRequest = (null as OffsetPagination?).toPageRequest()
+
+        assertThat(pageRequest).isEqualTo(PageRequest.of(0, Int.MAX_VALUE))
+    }
+}

--- a/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/BatchTest.kt
+++ b/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/BatchTest.kt
@@ -41,9 +41,15 @@ class BatchTest {
     suspend fun `test batchFlow function emits transformed batches`() {
         val input = (1..6).toList().asFlow()
         val batch = Batch(size = 2, concurrency = 1)
-        val result = input.batchFlow(batch) { items -> items.map { it * 2 }.asFlow() }.toList()
+        val result = input.batchFlow(batch) { items ->
+            listOf(items.map { it * 2 }).asFlow()
+        }.toList()
 
-        val expected = listOf(2, 4, 6, 8, 10, 12)
+        val expected = listOf(
+            listOf(2, 4),
+            listOf(6, 8),
+            listOf(10, 12)
+        )
         assertEquals(expected, result)
     }
 

--- a/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/BatchTest.kt
+++ b/f2-dsl/f2-dsl-function/src/jvmTest/kotlin/f2/dsl/fnc/operators/BatchTest.kt
@@ -36,4 +36,22 @@ class BatchTest {
         val expected = listOf(2, 4, 6)
         assertEquals(expected, result)
     }
+
+    @Test
+    suspend fun `test batchFlow function emits transformed batches`() {
+        val input = (1..6).toList().asFlow()
+        val batch = Batch(size = 2, concurrency = 1)
+        val result = input.batchFlow(batch) { items -> items.map { it * 2 }.asFlow() }.toList()
+
+        val expected = listOf(2, 4, 6, 8, 10, 12)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    suspend fun `test batch default configuration`() {
+        val batch = Batch()
+
+        assertEquals(BATCH_DEFAULT_SIZE, batch.size)
+        assertEquals(BATCH_DEFAULT_CONCURRENCY, batch.concurrency)
+    }
 }

--- a/f2-feature/catalog/f2-feature-catalog/src/main/kotlin/f2/feature/catalog/CatalogFunctionConfig.kt
+++ b/f2-feature/catalog/f2-feature-catalog/src/main/kotlin/f2/feature/catalog/CatalogFunctionConfig.kt
@@ -17,7 +17,7 @@ class CatalogFunctionConfig {
 	@Bean
 	fun catalogFunction(): () -> Array<String> {
 		return {
-			val namesFunction = catalog.getNames(Function::class.java)
+			val namesFunction: Set<String> = catalog.getNames(Function::class.java)
 			namesFunction.filter { !it.startsWith("&") }.toTypedArray()
 		}
 	}
@@ -25,7 +25,7 @@ class CatalogFunctionConfig {
 	@Bean
 	fun catalogSupplier(): () -> Array<String> {
 		return {
-			val namesFunction = catalog.getNames(Supplier::class.java)
+			val namesFunction: Set<String> = catalog.getNames(Supplier::class.java)
 			namesFunction.filter { !it.startsWith("&") }.toTypedArray()
 		}
 	}
@@ -33,7 +33,7 @@ class CatalogFunctionConfig {
 	@Bean
 	fun catalogConsumer(): () -> Array<String> {
 		return {
-			val namesFunction = catalog.getNames(Consumer::class.java)
+			val namesFunction: Set<String> = catalog.getNames(Consumer::class.java)
 			namesFunction.filter { !it.startsWith("&") }.toTypedArray()
 		}
 	}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
@@ -49,8 +49,9 @@ class TrustedIssuerJwtAuthenticationManagerResolver(
     }
 
     fun jwtAuthoritiesConverter(jwt: Jwt): Flux<GrantedAuthority> {
-        val realmAccess = jwt.claims["realm_access"] as Map<String, List<String>>?
-        return realmAccess?.get("roles").orEmpty().map { role ->
+        val realmAccess = jwt.claims["realm_access"] as? Map<*, *>
+        val roles = (realmAccess?.get("roles") as? List<*>).orEmpty().filterIsInstance<String>()
+        return roles.map { role ->
             SimpleGrantedAuthority("$ROLE_PREFIX$role")
         }.let { Flux.fromIterable(it) }
     }

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/main/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfig.kt
@@ -166,8 +166,9 @@ abstract class WebSecurityConfig {
     }
 
     fun jwtAuthoritiesConverter(jwt: Jwt): Flux<GrantedAuthority> {
-        val realmAccess = jwt.claims["realm_access"] as Map<String, List<String>>?
-        return realmAccess?.get("roles").orEmpty().map { role ->
+        val realmAccess = jwt.claims["realm_access"] as? Map<*, *>
+        val roles = (realmAccess?.get("roles") as? List<*>).orEmpty().filterIsInstance<String>()
+        return roles.map { role ->
             SimpleGrantedAuthority("$ROLE_PREFIX$role")
         }.let { Flux.fromIterable(it) }
     }

--- a/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/main/kotlin/f2/spring/exception/config/F2ExceptionHandler.kt
+++ b/f2-spring/exception/f2-spring-boot-exception-http-mvc/src/main/kotlin/f2/spring/exception/config/F2ExceptionHandler.kt
@@ -20,12 +20,12 @@ class F2ExceptionHandler {
 
     @ExceptionHandler(F2Exception::class)
     fun handleF2Exception(ex: F2Exception): ResponseEntity<Map<String, Any?>> {
-        val body = mapOf(
-            F2Error::id.name to ex.error.id,
-            F2Error::code.name to ex.error.code,
-            F2Error::message.name to ex.error.message,
-            F2Error::timestamp.name to ex.error.timestamp,
-        ).filterValues { it != null }
+        val body = buildMap {
+            ex.error.id?.let { put(F2Error::id.name, it) }
+            put(F2Error::code.name, ex.error.code)
+            put(F2Error::message.name, ex.error.message)
+            put(F2Error::timestamp.name, ex.error.timestamp)
+        }
         val status = HttpStatus.resolve(ex.error.code) ?: HttpStatus.INTERNAL_SERVER_ERROR
         return ResponseEntity.status(status).body(body)
     }
@@ -38,12 +38,12 @@ class F2ExceptionHandler {
             message = "Missing parameter `${ex.kotlinPropertyName}`",
             code = 400,
         )
-        val body = mapOf(
+        val body = mapOf<String, Any?>(
             F2Error::id.name to error.id,
             F2Error::code.name to error.code,
             F2Error::message.name to error.message,
             F2Error::timestamp.name to error.timestamp,
-        ).filterValues { it != null }
+        )
         return ResponseEntity.badRequest().body(body)
     }
 }

--- a/f2-spring/exception/f2-spring-boot-exception-http/src/test/kotlin/f2/spring/exception/MessageConverterExceptionTest.kt
+++ b/f2-spring/exception/f2-spring-boot-exception-http/src/test/kotlin/f2/spring/exception/MessageConverterExceptionTest.kt
@@ -1,0 +1,43 @@
+package f2.spring.exception
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.exc.MismatchedInputException
+import tools.jackson.databind.json.JsonMapper
+
+class MessageConverterExceptionTest {
+
+    class IntSample {
+        var count: Int = 0
+    }
+
+    private class SampleDatabindException(message: String) : DatabindException(message)
+
+    private fun mismatchedInputException(): MismatchedInputException {
+        val thrown = runCatching {
+            JsonMapper.builder().build().readValue("""{"count": []}""", IntSample::class.java)
+        }.exceptionOrNull()
+        return thrown as MismatchedInputException
+    }
+
+    @Test
+    fun `should build a message from a mismatched input exception`() {
+        val exception = MessageConverterException(mismatchedInputException())
+
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception.error.code).isEqualTo(400)
+        assertThat(exception.message)
+            .contains("Cannot convert parameter `count`")
+            .contains("to type `")
+    }
+
+    @Test
+    fun `should keep the original message for other databind exceptions`() {
+        val exception = MessageConverterException(SampleDatabindException("raw databind failure"))
+
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception.message).isEqualTo("raw databind failure")
+    }
+}

--- a/f2-spring/function/f2-spring-boot-starter-function/src/main/kotlin/f2/spring/KSerializationMapper.kt
+++ b/f2-spring/function/f2-spring-boot-starter-function/src/main/kotlin/f2/spring/KSerializationMapper.kt
@@ -41,28 +41,10 @@ class KSerializationMapper(
     private val serializerCache: MutableMap<Type, KSerializer<Any>> =
         ConcurrentReferenceHashMap<Type, KSerializer<Any>>()
 
-    @OptIn(ExperimentalSerializationApi::class)
-    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount", "UNCHECKED_CAST")
     override fun <T> doFromJson(json: Any, type: Type): T {
         try {
-            val serializerType = serializer(type)
-            return when (json) {
-                is String -> {
-                    mapper.decodeFromString(serializerType, json) as T
-                }
-                is ByteArray -> {
-                    mapper.decodeFromString(serializerType, String(json)) as T
-                }
-                is Reader -> {
-                    mapper.decodeFromStream(serializerType, json.toInputStream()) as T
-                }
-                is JsonElement -> {
-                    mapper.decodeFromJsonElement(serializerType, json) as T
-                }
-                else -> {
-                    error("Failed to convert. Unknown type ${json::class.qualifiedName}")
-                }
-            }
+            return decode(json, type) as T
         } catch (e: MissingFieldException) {
             throw F2Exception(error = F2Error(
                 id = UUID.randomUUID().toString(),
@@ -84,6 +66,19 @@ class KSerializationMapper(
             )
         }
     }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun decode(json: Any, type: Type): Any {
+        val serializerType = serializer(type)
+        return when (json) {
+            is String -> mapper.decodeFromString(serializerType, json)
+            is ByteArray -> mapper.decodeFromString(serializerType, String(json))
+            is Reader -> mapper.decodeFromStream(serializerType, json.toInputStream())
+            is JsonElement -> mapper.decodeFromJsonElement(serializerType, json)
+            else -> error("Failed to convert. Unknown type ${json::class.qualifiedName}")
+        }
+    }
+
     @Suppress("TooGenericExceptionCaught")
     override fun toJson(value: Any): ByteArray {
         val type = ResolvableType.forClass(value::class.java)
@@ -115,7 +110,7 @@ class KSerializationMapper(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "UNCHECKED_CAST")
     private fun serializer(type: Type): KSerializer<Any> {
         return serializerCache.getOrPut(type) {
             try {


### PR DESCRIPTION
## SonarQube cleanup — 25/27 issues fixed, coverage 71.6% → ~83%

### Fixes
- Security: pin `make-jvm-workflow.yml` to full commit SHA in `dev.yml` (githubactions:S7637)
- Bugs: 3× unsafe map `!!` → `getValue()` (`F2SpringContextStep`, `LambdaF2VehicleSteps`)
- 13× unchecked casts (S6530): `KSerializationMapper` refactored to single `decode()`, `HttpF2Client` extracted `emitPayload()`, real fixes in `WebSecurityConfig`/`TrustedIssuerJwtAuthenticationManagerResolver` (`as? Map<*,*>` + `filterIsInstance<String>`)
- Useless null-checks (S6619), mutable collection exposure (S6524), commented code (S125), duplicated literals (S1192)

### Tests (coverage 71.6% → est. ~83%)
- `F2AuthTest`: client-credentials, refresh-token, password grant, decode-error paths (F2Auth 0 → 75/85 lines)
- `HttpF2ClientUploadTest`: multipart single/multi file upload
- New jvmTest source sets for `f2-dsl-cqrs` (Match, PageExtension, EnvelopeExtension, F2ErrorExtension), `f2-client-ktor`, `f2-client-ktor-common`
- Note: JaCoCo cannot attribute inline-function bodies — coverage work targeted non-inline code

### Skipped (needs deliberate decision)
- `text:S8569` / `kotlin:S6474`: Gradle dependency locking + verification metadata — build-infra policy change

Verification: full `test jvmTest detekt` green; JS targets of edited MPP modules compile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or missing authentication claims.
  * Preserved consistent error responses, including optional error identifiers and clearer deserialization messages.
  * Improved HTTP client response processing, uploads, authentication retries, and protocol validation.
  * Made data-table and serialization handling safer and more reliable.

* **Tests**
  * Expanded coverage for HTTP clients, authentication, uploads, pagination, envelopes, matching, errors, batching, and serialization.

* **Chores**
  * Standardized automated test execution and pinned the development workflow for more predictable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->