### PR TITLE
feat: add @JsExport to F2 client and DSL public types

### DIFF
--- a/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/TokenInfo.kt
+++ b/f2-client/f2-client-domain/src/commonMain/kotlin/f2/client/domain/TokenInfo.kt
@@ -1,8 +1,10 @@
 package f2.client.domain
 
+import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@JsExport
 @Serializable
 data class TokenInfo(
     @SerialName("access_token") val accessToken: String,

--- a/f2-client/f2-client-ktor/f2-client-ktor-common/src/commonMain/kotlin/f2/client/ktor/common/Json.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-common/src/commonMain/kotlin/f2/client/ktor/common/Json.kt
@@ -1,7 +1,9 @@
 package f2.client.ktor.common
 
+import kotlin.js.JsExport
 import kotlinx.serialization.json.Json
 
+@JsExport
 val F2DefaultJson: Json = Json {
     encodeDefaults = true
     isLenient = true

--- a/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/model/F2UploadCommand.kt
+++ b/f2-client/f2-client-ktor/f2-client-ktor-http/src/commonMain/kotlin/f2/client/ktor/http/model/F2UploadCommand.kt
@@ -1,14 +1,17 @@
 package f2.client.ktor.http.model
 
 import io.ktor.utils.io.ByteReadChannel
+import kotlin.js.JsExport
 
 typealias F2FileKey = String
 
+@JsExport
 interface F2UploadCommand<COMMAND> {
     val command: COMMAND
     val fileMap: Map<F2FileKey, Collection<F2FilePart>>
 }
 
+@JsExport
 data class F2UploadSingleCommand<COMMAND>(
     override val command: COMMAND,
     val file: F2FilePart
@@ -16,6 +19,7 @@ data class F2UploadSingleCommand<COMMAND>(
     override val fileMap: Map<F2FileKey, Collection<F2FilePart>> = mapOf("file" to listOf(file))
 }
 
+@JsExport
 data class F2UploadMultipleCommand<COMMAND>(
     override val command: COMMAND,
     val files: Collection<F2FilePart>
@@ -23,6 +27,7 @@ data class F2UploadMultipleCommand<COMMAND>(
     override val fileMap: Map<F2FileKey, Collection<F2FilePart>> = mapOf("file" to files)
 }
 
+@JsExport
 data class F2FilePart(
     val name: String,
     val content: ByteReadChannel,

--- a/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/F2ClientBuilder.kt
+++ b/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/F2ClientBuilder.kt
@@ -4,10 +4,13 @@ import f2.client.F2Client
 import f2.client.ktor.common.F2ClientConfigLambda
 import f2.client.ktor.http.httpClientBuilderDefault
 import f2.client.ktor.http.httpClientBuilderGenerics
+import kotlin.js.JsExport
+import kotlin.js.JsName
 
 /**
  * Builder object for creating instances of [F2Client] based on different protocols.
  */
+@JsExport
 object F2ClientBuilder {
 
     private const val HTTP_PREFIX = "http:"
@@ -40,6 +43,7 @@ object F2ClientBuilder {
      * @return An instance of [F2Client].
      * @throws InvalidUrlException if the URL does not start with a valid protocol.
      */
+    @JsName("getWithConfig")
     suspend fun get(
         urlBase: String,
         config: F2ClientConfigLambda<*>? = null

--- a/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/InvalidUrlException.kt
+++ b/f2-client/f2-client-ktor/src/commonMain/kotlin/f2/client/ktor/InvalidUrlException.kt
@@ -1,3 +1,6 @@
 package f2.client.ktor
 
+import kotlin.js.JsExport
+
+@JsExport
 class InvalidUrlException(url: String): Exception("$url is invalid")

--- a/f2-dsl/f2-dsl-cqrs/src/commonMain/kotlin/f2/dsl/cqrs/envelope/WithEnvelopeData.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/commonMain/kotlin/f2/dsl/cqrs/envelope/WithEnvelopeData.kt
@@ -1,10 +1,13 @@
 package f2.dsl.cqrs.envelope
 
+import kotlin.js.JsExport
+
 /**
  * Interface representing an entity that contains data of type T.
  *
  * @param <T> The type of the data contained in the envelope.
  */
+@JsExport
 interface WithEnvelopeData<T> {
     /**
      * The data contained in the envelope.

--- a/f2-dsl/f2-dsl-cqrs/src/commonMain/kotlin/f2/dsl/cqrs/envelope/WithEnvelopeId.kt
+++ b/f2-dsl/f2-dsl-cqrs/src/commonMain/kotlin/f2/dsl/cqrs/envelope/WithEnvelopeId.kt
@@ -1,8 +1,11 @@
 package f2.dsl.cqrs.envelope
 
+import kotlin.js.JsExport
+
 /**
  * Interface representing an entity that contains an ID.
  */
+@JsExport
 interface WithEnvelopeId {
     /**
      * The ID of the envelope.


### PR DESCRIPTION
## Summary
Adds `@JsExport` to F2 client and DSL public types so the Kotlin/JS artifact exposes clean, non-mangled names and generates proper `.d.ts` typings for JS/TS consumers.

## Changes
- **Client**
  - `TokenInfo` (`f2-client-domain`)
  - `F2DefaultJson` (`f2-client-ktor-common`)
  - `F2UploadCommand`, `F2UploadSingleCommand`, `F2UploadMultipleCommand`, `F2FilePart` (`f2-client-ktor-http`)
  - `F2ClientBuilder` — plus `@JsName("getWithConfig")` to disambiguate the overloaded `get()` (JS has no overloading)
  - `InvalidUrlException`
- **DSL**
  - `WithEnvelopeData`, `WithEnvelopeId` (`f2-dsl-cqrs`)

## Notes
- Completes the `@JsExport` pass over the JS-target `commonMain` surface; remaining unannotated `commonMain` files are typealiases, `Flow`/`suspend` extension operators, or `expect` decls whose JS `actual` is already annotated — none are exportable by Kotlin/JS rules.

## Verification
- `./gradlew compileKotlinJvm compileKotlinJs` — BUILD SUCCESSFUL (JVM + JS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded JavaScript interoperability across client and DSL APIs.
  * Exposed token information, JSON configuration, upload commands, client creation, URL errors, and envelope interfaces to JavaScript.
  * Added a JavaScript-friendly client configuration method name for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->