### PR TITLE
fix: document CoroutinesUtils.kt as vendored and mark its KOMUNE hunks

### DIFF
--- a/.claude/skills/upgrading-spring-cloud-function/SKILL.md
+++ b/.claude/skills/upgrading-spring-cloud-function/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: upgrading-spring-cloud-function
-description: Use when bumping F2's spring-cloud-function version, when a KOMUNE-patched vendored file (SimpleFunctionRegistry, JsonMessageConverter, SmartCompositeMessageConverter, FunctionWebRequestProcessingHelper, ContextFunctionCatalogAutoConfiguration, KotlinLambdaToFunctionAutoConfiguration) needs updating, or when syncing komune-io/spring-cloud-function fork branches (fixers/<version>) with upstream spring-cloud/spring-cloud-function releases.
+description: Use when bumping F2's spring-cloud-function version, when a KOMUNE-patched vendored file (SimpleFunctionRegistry, JsonMessageConverter, SmartCompositeMessageConverter, FunctionWebRequestProcessingHelper, ContextFunctionCatalogAutoConfiguration, KotlinLambdaToFunctionAutoConfiguration, CoroutinesUtils) needs updating, or when syncing komune-io/spring-cloud-function fork branches (fixers/<version>) with upstream spring-cloud/spring-cloud-function releases.
 ---
 
 # Upgrading spring-cloud-function
 
 ## Overview
 
-F2 vendors (shadows by package/path) 6 Java files from `spring-cloud-function`, each carrying small custom patches marked `// KOMUNE Modification` … `// KOMUNE End Of Modification`. A sibling repo, `komune-io/spring-cloud-function`, carries the identical patch on branches named `fixers/<version>` (e.g. `fixers/5.0.3`) off the matching upstream tag — this is the fork PR upstream would see, kept in sync with F2's vendored copies.
+F2 vendors (shadows by package/path) 7 files from `spring-cloud-function` — 6 Java files plus `CoroutinesUtils.kt` — each carrying custom patches marked `// KOMUNE Modification` … `// KOMUNE End Of Modification` (`CoroutinesUtils.kt` uses `//KOMUNE Changes Start` … `//KOMUNE Changes End`). A sibling repo, `komune-io/spring-cloud-function`, carries the identical patch on branches named `fixers/<version>` (e.g. `fixers/5.0.3`) off the matching upstream tag — this is the fork PR upstream would see, kept in sync with F2's vendored copies.
 
 Upgrading means: find the new tag, check which vendored files actually changed upstream, reapply only the KOMUNE hunks that survive (not a wholesale merge), and verify the patches are still load-bearing — in both repos, kept in sync.
 
@@ -30,6 +30,9 @@ The other checkout, the local clone of `komune-io/spring-cloud-function`, is mac
 | `FunctionWebRequestProcessingHelper.java` | Drop `onErrorContinue` on the result stream | Necessary — but only reproduces with a fixture that fails *inside* an operator (e.g. `.map()`); a source that throws directly doesn't exercise it at all, `onErrorContinue` can't intercept a source-terminal error |
 | `KotlinLambdaToFunctionAutoConfiguration.java` | Relaxed suspend supplier/consumer/function arity detection + supertype-aware matching | Necessary — F2's DSL types erase to fewer Java arities than upstream's detector expects |
 | `ContextFunctionCatalogAutoConfiguration.java` | `kSerialization` JsonMapper branch | F2-specific; the fork keeps it commented out (can't depend on F2's `f2.spring.KSerializationMapper`) — never try to make this identical between the two repos |
+| `CoroutinesUtils.kt` | `invokeSuspendingSupplier` accepts a supplier returning a plain value, not only a `Flow` (wraps it with `flowOf`) | Necessary — `F2Supplier<T>` erases to a lambda returning the value itself; upstream's `suspendCoroutineUninterceptedOrReturn<Flow<Any>>` blows up on it |
+| `CoroutinesUtils.kt` | `require(...)` argument checks in `invokeSuspendingFunction`/`Consumer`/`Supplier` instead of upstream's blind casts | Defensive — turns a bare `ClassCastException` from a mis-wired bean into a readable message |
+| `CoroutinesUtils.kt` | `typealias` made public (upstream: `private typealias`) + `@Suppress("TooManyFunctions")`/`@Suppress("ReturnCount")` | Build-only — detekt runs over F2's copy, upstream's build doesn't |
 
 Also: `spring-cloud-function-context/pom.xml` (fork only) comments out `spring-web`'s `<optional>true</optional>` — needed because `ResponseStatusException` lives in `spring-web`.
 
@@ -72,6 +75,7 @@ FILES=(
   "spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/JsonMessageConverter.java"
   "spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/KotlinLambdaToFunctionAutoConfiguration.java"
   "spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/config/SmartCompositeMessageConverter.java"
+  "spring-cloud-function-context/src/main/kotlin/org/springframework/cloud/function/context/config/CoroutinesUtils.kt"
   "spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/util/FunctionWebRequestProcessingHelper.java"
 )
 for f in "${FILES[@]}"; do
@@ -125,7 +129,7 @@ F2 (Gradle), run from this repo's root: `./gradlew test detekt`.
 ```bash
 /usr/bin/diff -w -B "<f2-path>" <(git -C "$SPRING_CLOUD_FUNCTION_REPO" show origin/fixers/<version>:"<fork-path>" | expand -t4)
 ```
-Expect **0** for `SimpleFunctionRegistry.java` and `FunctionWebRequestProcessingHelper.java`. The other four (`ContextFunctionCatalogAutoConfiguration.java`, `KotlinLambdaToFunctionAutoConfiguration.java`, `JsonMessageConverter.java`, `SmartCompositeMessageConverter.java`) legitimately show small nonzero diffs even when fully in sync — copyright-header years, one import's position, and F2's own `kSerialization` feature that the fork can't have. Don't treat those as a failure signal; confirm they're *pre-existing* by diffing the same files against the *previous* fork branch too — if the counts match, nothing regressed.
+Expect **0** for `SimpleFunctionRegistry.java` and `FunctionWebRequestProcessingHelper.java`. `CoroutinesUtils.kt` is out of scope for this check entirely: as of `fixers/5.0.3` the fork carries upstream's copy verbatim (no KOMUNE markers), so F2's version diverges heavily *by design* — diff it against **upstream** rather than the fork. The other four (`ContextFunctionCatalogAutoConfiguration.java`, `KotlinLambdaToFunctionAutoConfiguration.java`, `JsonMessageConverter.java`, `SmartCompositeMessageConverter.java`) legitimately show small nonzero diffs even when fully in sync — copyright-header years, one import's position, and F2's own `kSerialization` feature that the fork can't have. Don't treat those as a failure signal; confirm they're *pre-existing* by diffing the same files against the *previous* fork branch too — if the counts match, nothing regressed.
 
 ### 8. Branch, commit, push — only on explicit confirmation
 
@@ -135,6 +139,7 @@ Fork: `git checkout -b fixers/<new-version> v<new-version>`, commit the patch. F
 
 - **Trusting a network-fetched `diff <(...) <(...)`** — verified false-negative twice in one session (once during initial BOM investigation, once during "independent" re-verification of the same claim). Save to real files and diff those.
 - **Assuming a hunk's necessity carries over** from the last time it was checked — re-verify by removal-proof against the new base, don't just cite the old table.
-- **Treating the fork/F2 sync-check's expected nonzero files as a regression** — 4 of 6 vendored files have permanent, harmless cosmetic drift; only `SimpleFunctionRegistry.java` and `FunctionWebRequestProcessingHelper.java` should ever be byte-identical.
+- **Treating the fork/F2 sync-check's expected nonzero files as a regression** — 4 of the 6 Java files have permanent, harmless cosmetic drift; only `SimpleFunctionRegistry.java` and `FunctionWebRequestProcessingHelper.java` should ever be byte-identical, and `CoroutinesUtils.kt` isn't mirrored in the fork at all.
+- **Forgetting `CoroutinesUtils.kt` is vendored** — it's Kotlin, it lives under `src/main/kotlin`, it has no fork counterpart, and it uses a different marker style (`//KOMUNE Changes Start`/`End`), so every "the 6 Java files" shortcut silently skips it.
 - **zsh array indexing** — a paired-array verification loop written assuming 0-indexed arrays can misbehave under zsh's default 1-indexed arrays. Prefer a single array of `"a::b"` pairs split with `${x%%::*}`/`${x##*::}` over two parallel indexed arrays, or just run under `bash` explicitly.
 - **Forgetting the `spring-web` pom.xml hunk** on the fork side — it's easy to miss since it's not a `.java` file and doesn't show up in a vendored-file-only diff sweep.

--- a/f2-spring/function/f2-spring-boot-starter-function/src/main/kotlin/org/springframework/cloud/function/context/config/CoroutinesUtils.kt
+++ b/f2-spring/function/f2-spring-boot-starter-function/src/main/kotlin/org/springframework/cloud/function/context/config/CoroutinesUtils.kt
@@ -15,7 +15,10 @@
  */
 
 @file:JvmName("CoroutinesUtils")
+//KOMUNE Changes Start
+// detekt runs over this vendored file, upstream's build does not
 @file:Suppress("TooManyFunctions")
+//KOMUNE Changes End
 package org.springframework.cloud.function.context.config
 
 import java.lang.reflect.ParameterizedType
@@ -40,7 +43,10 @@ fun getSuspendingFunctionArgType(type: Type): Type {
 	return getFlowTypeArguments(type)
 }
 
+//KOMUNE Changes Start
+// detekt runs over this vendored file, upstream's build does not
 @Suppress("ReturnCount")
+//KOMUNE Changes End
 fun getFlowTypeArguments(type: Type): Type {
 	if(!isFlowType(type)) {
 		return type
@@ -89,6 +95,11 @@ private fun getContinuationTypeArguments(type: Type): Type {
 	return wildcardType.lowerBounds[0]
 }
 
+//KOMUNE Changes Start
+// Upstream blind-casts its arguments; F2 checks them first so a wrongly wired bean fails with a
+// readable message instead of a bare ClassCastException.
+// invokeSuspendingSupplier additionally accepts a supplier that returns a plain value rather than a
+// Flow (F2Supplier<T> erases to that) and wraps it with flowOf; upstream assumes a Flow and blows up.
 @Suppress("UNCHECKED_CAST")
 fun invokeSuspendingFunction(kotlinLambdaTarget: Any, arg0: Any): Flux<Any> {
 	require(kotlinLambdaTarget is Function2<*, *, *>) {
@@ -131,6 +142,9 @@ fun invokeSuspendingSupplier(kotlinLambdaTarget: Any): Flux<Any> {
 }
 //KOMUNE Changes End
 
+//KOMUNE Changes Start
+// Same argument checking as above; `arg0.asFlow()` relies on the smart cast from the require, where
+// upstream casts arg0 to Flux<Any> unchecked.
 @Suppress("UNCHECKED_CAST")
 fun invokeSuspendingConsumer(kotlinLambdaTarget: Any, arg0: Any) {
 	require(kotlinLambdaTarget is Function2<*, *, *>) {
@@ -146,6 +160,7 @@ fun invokeSuspendingConsumer(kotlinLambdaTarget: Any, arg0: Any) {
 		}
 	}.subscribe()
 }
+//KOMUNE Changes End
 
 fun isValidSuspendingFunction(kotlinLambdaTarget: Any, arg0: Any): Boolean {
 	return arg0 is Flux<*> && kotlinLambdaTarget is Function2<*, *, *>
@@ -155,6 +170,9 @@ fun isValidSuspendingSupplier(kotlinLambdaTarget: Any): Boolean {
 	return kotlinLambdaTarget is Function1<*, *>
 }
 
+//KOMUNE Changes Start
+// Upstream declares these `private typealias`; F2 keeps them public.
 typealias SuspendFunction = (Any?, Any?) -> Any?
 typealias SuspendConsumer = (Any?, Any?) -> Unit?
 typealias SuspendSupplier = (Any?) -> Any?
+//KOMUNE Changes End


### PR DESCRIPTION
Closes #127.

`.claude/skills/upgrading-spring-cloud-function/` **is** tracked (`git ls-files` returns `SKILL.md`), so both halves of the fix are in this PR.

## What changed

### `SKILL.md`
- Overview and frontmatter: **7** vendored files (6 Java + `CoroutinesUtils.kt`), and a note that `CoroutinesUtils.kt` uses `//KOMUNE Changes Start`/`End` rather than `// KOMUNE Modification`/`// KOMUNE End Of Modification`.
- `CoroutinesUtils.kt` added to the step-3 `FILES` array.
- Three new patch-table rows (see below).
- Step 7 (fork/F2 sync check) and the common-mistakes list updated.

### `CoroutinesUtils.kt`
Proper start/end markers around each divergence from upstream `v5.0.3`, and a start marker for the orphaned `//KOMUNE Changes End` that was sitting at the end of `invokeSuspendingSupplier`. No behaviour change — comments and markers only.

Divergences found by diffing against `spring-cloud/spring-cloud-function@v5.0.3`:

| Divergence | Kind |
|---|---|
| `invokeSuspendingSupplier` uses `suspendCoroutineUninterceptedOrReturn<Any>` and wraps a non-`Flow` result with `flowOf` | Functional — `F2Supplier<T>` erases to a lambda returning the value itself; upstream's `<Flow<Any>>` blows up on it |
| `require(...)` argument checks in `invokeSuspendingFunction`/`Consumer`/`Supplier` in place of upstream's blind casts | Defensive |
| `typealias` public where upstream has `private typealias` | Cosmetic |
| `@file:Suppress("TooManyFunctions")`, `@Suppress("ReturnCount")` | Build-only — detekt runs over F2's copy, upstream's build does not |

## One finding worth flagging

The sibling fork `komune-io/spring-cloud-function@fixers/5.0.3` carries **upstream's `CoroutinesUtils.kt` verbatim** — 132 lines, zero `KOMUNE` markers, byte-identical to `v5.0.3` modulo whitespace. So unlike the 6 Java files, this one has no fork counterpart and step 7's fork/F2 sync check does not apply to it; it must be diffed against upstream instead. SKILL.md now says so explicitly.

## Verification

`./gradlew :f2-spring:function:f2-spring-boot-starter-function:compileKotlin :f2-spring:function:f2-spring-boot-starter-function:detekt` — BUILD SUCCESSFUL (targeted module only, not a full build).