### PR TITLE
test: Spring Security filter-chain integration tests for auth starters

### DIFF
--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.bundles.spring.test)
+    testImplementation(libs.spring.boot.starter.webflux)
 }

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakAuthTestApp.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakAuthTestApp.kt
@@ -1,0 +1,33 @@
+package io.komune.f2.spring.boot.auth.keycloak
+
+import io.komune.f2.spring.boot.auth.config.F2TrustedIssuersConfig
+import io.komune.f2.spring.boot.auth.config.WebSecurityConfig
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.router
+
+/**
+ * Boots the Keycloak starter (`KeycloakConfigEndpoint`, `KeycloakConfigResolver`, `F2KeycloakConfig`)
+ * behind the real [WebSecurityConfig] filter chain, so the `@PermitAll` declared on the `keycloak`
+ * bean is actually exercised by Spring Security.
+ */
+@SpringBootApplication
+class KeycloakAuthTestApp {
+
+    @Configuration
+    @EnableConfigurationProperties(F2TrustedIssuersConfig::class)
+    class TestWebSecurityConfig : WebSecurityConfig()
+
+    @Bean("securedFunction")
+    fun securedFunction(): () -> String = { "secured" }
+
+    @Bean
+    fun routes(): RouterFunction<ServerResponse> = router {
+        GET("/keycloak") { ServerResponse.ok().bodyValue("keycloak-config") }
+        GET("/securedFunction") { ServerResponse.ok().bodyValue("secured") }
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigEndpointIntegrationTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-keycloak/src/test/kotlin/io/komune/f2/spring/boot/auth/keycloak/KeycloakConfigEndpointIntegrationTest.kt
@@ -1,0 +1,87 @@
+package io.komune.f2.spring.boot.auth.keycloak
+
+import io.komune.f2.spring.boot.auth.config.F2TrustedIssuersConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * Covers the Keycloak starter inside a running application: `f2.issuers[*]` binding into both
+ * [F2KeycloakConfig] and [F2TrustedIssuersConfig], and the fact that the `keycloak` configuration
+ * endpoint is reachable anonymously (it is annotated `@PermitAll`) while the rest of the
+ * application requires a token.
+ */
+@SpringBootTest(
+    classes = [KeycloakAuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "f2.issuers[0].name=first",
+        "f2.issuers[0].auth-url=http://localhost:8080/auth",
+        "f2.issuers[0].realm=master",
+        "f2.issuers[0].web.client-id=web-client",
+        "f2.issuers[1].name=second",
+        "f2.issuers[1].auth-url=http://localhost:8081/auth",
+        "f2.issuers[1].realm=tenant"
+    ]
+)
+class KeycloakConfigEndpointIntegrationTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var keycloakConfig: F2KeycloakConfig
+
+    @Autowired
+    private lateinit var trustedIssuersConfig: F2TrustedIssuersConfig
+
+    @Autowired
+    private lateinit var keycloakEndpoint: KeycloakConfigEndpoint
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    @Test
+    fun `f2 issuers should bind to KeycloakIssuers including the optional web client id`() {
+        assertThat(keycloakConfig.issuers).hasSize(2)
+        assertThat(keycloakConfig.getConfig()).containsOnlyKeys("first", "second")
+        assertThat(keycloakConfig.getConfig()["first"]).isEqualTo(
+            KeycloakConfig(realm = "master", authServerUrl = "http://localhost:8080/auth", resource = "web-client")
+        )
+        assertThat(keycloakConfig.getConfig()["second"]).isEqualTo(
+            KeycloakConfig(realm = "tenant", authServerUrl = "http://localhost:8081/auth", resource = null)
+        )
+    }
+
+    @Test
+    fun `the same f2 issuers should bind to the trusted issuers of the security config`() {
+        assertThat(trustedIssuersConfig.getTrustedIssuers()).containsExactly(
+            "http://localhost:8080/auth/realms/master",
+            "http://localhost:8081/auth/realms/tenant"
+        )
+    }
+
+    @Test
+    fun `keycloak endpoint bean should resolve the config of the requested issuer`() {
+        assertThat(keycloakEndpoint.keycloak()("second")).isEqualTo(
+            KeycloakConfig(realm = "tenant", authServerUrl = "http://localhost:8081/auth", resource = null)
+        )
+    }
+
+    @Test
+    fun `keycloak config endpoint should be reachable without a token`() {
+        webTestClient.get().uri("/keycloak").exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("keycloak-config")
+    }
+
+    @Test
+    fun `other endpoints should still require authentication`() {
+        webTestClient.get().uri("/securedFunction").exchange()
+            .expectStatus().isUnauthorized
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/OidcProviderStub.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/OidcProviderStub.kt
@@ -1,0 +1,107 @@
+package io.komune.f2.spring.boot.auth.config
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+
+/**
+ * In-process OpenID provider stub: serves an openid-configuration document and a JWKS per realm,
+ * and mints JWTs signed with the matching realm key.
+ *
+ * Everything is local (loopback HTTP + locally generated RSA keys), so no Keycloak instance and no
+ * network egress is needed to exercise the resource-server filter chain end to end.
+ */
+class OidcProviderStub(realms: List<String>) {
+
+    private val server: HttpServer = HttpServer.create(InetSocketAddress(0), 0)
+    private val keys: Map<String, RSAKey> = realms.associateWith { realm ->
+        RSAKeyGenerator(RSA_KEY_SIZE)
+            .keyID("$realm-key")
+            .generate()
+    }
+
+    val authUrl: String get() = "http://localhost:${server.address.port}/auth"
+
+    init {
+        realms.forEach { realm ->
+            val issuer = issuer(realm)
+            server.createContext("/auth/realms/$realm/.well-known/openid-configuration") { exchange ->
+                exchange.respondJson(
+                    """
+                    {
+                      "issuer": "$issuer",
+                      "jwks_uri": "$issuer/protocol/openid-connect/certs"
+                    }
+                    """.trimIndent()
+                )
+            }
+            server.createContext("/auth/realms/$realm/protocol/openid-connect/certs") { exchange ->
+                exchange.respondJson(JWKSet(keys.getValue(realm).toPublicJWK()).toString())
+            }
+        }
+        server.start()
+    }
+
+    fun issuer(realm: String) = "$authUrl/realms/$realm"
+
+    fun stop() = server.stop(0)
+
+    /**
+     * @param realm the realm whose signing key is used
+     * @param issuer the `iss` claim, defaults to the realm issuer. Override it to simulate a token
+     * claiming to come from another issuer while being signed by [realm]'s key.
+     */
+    @Suppress("LongParameterList")
+    fun mintToken(
+        realm: String,
+        roles: List<String> = emptyList(),
+        issuer: String = issuer(realm),
+        subject: String = "user-1",
+        claims: Map<String, Any> = emptyMap(),
+        expiresAt: Instant = Instant.now().plusSeconds(EXPIRY_SECONDS)
+    ): String {
+        val key = keys.getValue(realm)
+        val claimsSet = JWTClaimsSet.Builder()
+            .issuer(issuer)
+            .subject(subject)
+            .jwtID(UUID.randomUUID().toString())
+            .issueTime(Date.from(Instant.now().minusSeconds(EXPIRY_SECONDS)))
+            .expirationTime(Date.from(expiresAt))
+            .claim("realm_access", mapOf("roles" to roles))
+            .apply { claims.forEach { (name, value) -> claim(name, value) } }
+            .build()
+
+        val header = JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(key.keyID)
+            .type(JOSEObjectType.JWT)
+            .build()
+
+        return SignedJWT(header, claimsSet)
+            .apply { sign(RSASSASigner(key)) }
+            .serialize()
+    }
+
+    private fun HttpExchange.respondJson(body: String) {
+        val bytes = body.toByteArray()
+        responseHeaders.add("Content-Type", "application/json")
+        sendResponseHeaders(200, bytes.size.toLong())
+        responseBody.use { it.write(bytes) }
+    }
+
+    companion object {
+        private const val RSA_KEY_SIZE = 2048
+        private const val EXPIRY_SECONDS = 3600L
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantAuthTestApp.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantAuthTestApp.kt
@@ -1,0 +1,35 @@
+package io.komune.f2.spring.boot.auth.config
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.router
+
+/**
+ * Minimal reactive application wiring the real tenant [WebSecurityConfig] filter chain, with one
+ * endpoint per authorization rule the config derives from bean annotations.
+ */
+@SpringBootApplication
+class TenantAuthTestApp {
+
+    @Bean("openFunction")
+    @PermitAll
+    fun openFunction(): () -> String = { "open" }
+
+    @Bean("adminFunction")
+    @RolesAllowed("admin")
+    fun adminFunction(): () -> String = { "admin" }
+
+    @Bean("securedFunction")
+    fun securedFunction(): () -> String = { "secured" }
+
+    @Bean
+    fun routes(): RouterFunction<ServerResponse> = router {
+        GET("/openFunction") { ServerResponse.ok().bodyValue("open") }
+        GET("/adminFunction") { ServerResponse.ok().bodyValue("admin") }
+        GET("/securedFunction") { ServerResponse.ok().bodyValue("secured") }
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantIssuerPrefixMatchingTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantIssuerPrefixMatchingTest.kt
@@ -1,0 +1,79 @@
+package io.komune.f2.spring.boot.auth.config
+
+import io.komune.f2.spring.boot.auth.security.TrustedIssuerJwtAuthenticationManagerResolver
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * Documents the current behaviour of [TrustedIssuerJwtAuthenticationManagerResolver], which trusts
+ * any issuer whose URI *starts with* `f2.tenant.issuer-base-uri` — no path-segment boundary is
+ * enforced.
+ *
+ * With a base URI that does not end with a separator (`.../realms/tenant-1`), a sibling issuer whose
+ * name merely shares that prefix (`.../realms/tenant-1-other`) is therefore accepted as trusted.
+ * This test asserts the behaviour as it is today so any change is deliberate; see the discussion on
+ * issue #123.
+ */
+@SpringBootTest(
+    classes = [TenantAuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class TenantIssuerPrefixMatchingTest {
+
+    companion object {
+        const val TENANT = "tenant-1"
+        const val SIBLING_TENANT = "tenant-1-other"
+
+        private val oidc = OidcProviderStub(listOf(TENANT, SIBLING_TENANT))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun issuerBaseUri(registry: DynamicPropertyRegistry) {
+            // note the missing trailing separator, which is what makes the prefix match too wide
+            registry.add("f2.tenant.issuer-base-uri") { "${oidc.authUrl}/realms/$TENANT" }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() = oidc.stop()
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    private fun getAdmin(token: String) = webTestClient.get()
+        .uri("/adminFunction")
+        .headers { it.setBearerAuth(token) }
+        .exchange()
+
+    @Test
+    fun `token of the configured tenant should be accepted`() {
+        getAdmin(oidc.mintToken(TENANT, roles = listOf("admin"))).expectStatus().isOk
+    }
+
+    @Test
+    fun `token of a sibling issuer sharing the base uri prefix is currently accepted`() {
+        // current behaviour: prefix matching has no segment boundary, so `tenant-1-other` passes the
+        // trust check even though only `tenant-1` was configured
+        getAdmin(oidc.mintToken(SIBLING_TENANT, roles = listOf("admin"))).expectStatus().isOk
+    }
+
+    @Test
+    fun `token of an unrelated issuer should still be rejected with 401`() {
+        val token = oidc.mintToken(
+            realm = TENANT,
+            roles = listOf("admin"),
+            issuer = "https://evil.example.com/realms/tenant-1"
+        )
+        getAdmin(token).expectStatus().isUnauthorized
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantWebSecurityConfigIntegrationTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/config/TenantWebSecurityConfigIntegrationTest.kt
@@ -1,0 +1,111 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * End-to-end coverage of the multi-tenant security filter chain: any issuer under
+ * `f2.tenant.issuer-base-uri` is trusted, everything else must be rejected. Tokens are minted
+ * locally by [OidcProviderStub], nothing leaves the loopback interface.
+ */
+@SpringBootTest(
+    classes = [TenantAuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class TenantWebSecurityConfigIntegrationTest {
+
+    companion object {
+        const val TENANT_1 = "tenant-1"
+        const val TENANT_2 = "tenant-2"
+
+        private val oidc = OidcProviderStub(listOf(TENANT_1, TENANT_2))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun issuerBaseUri(registry: DynamicPropertyRegistry) {
+            registry.add("f2.tenant.issuer-base-uri") { "${oidc.authUrl}/realms/" }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() = oidc.stop()
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    private fun get(path: String, token: String? = null) = webTestClient.get()
+        .uri(path)
+        .apply { token?.let { headers { headers -> headers.setBearerAuth(it) } } }
+        .exchange()
+
+    @Test
+    fun `unauthenticated request on a secured path should be rejected with 401`() {
+        get("/securedFunction").expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `PermitAll path should be reachable without any token`() {
+        get("/openFunction")
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("open")
+    }
+
+    @Test
+    fun `authenticated request with an insufficient role should be rejected with 403`() {
+        val token = oidc.mintToken(TENANT_1, roles = listOf("user"))
+        get("/adminFunction", token).expectStatus().isForbidden
+    }
+
+    @Test
+    fun `token of the first tenant should be accepted`() {
+        val token = oidc.mintToken(TENANT_1, roles = listOf("admin"))
+        get("/adminFunction", token)
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("admin")
+    }
+
+    @Test
+    fun `token of the second tenant should be accepted`() {
+        val token = oidc.mintToken(TENANT_2, roles = listOf("admin"))
+        get("/adminFunction", token)
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("admin")
+    }
+
+    @Test
+    fun `token issued outside of the tenant base uri should be rejected with 401`() {
+        val token = oidc.mintToken(
+            realm = TENANT_1,
+            roles = listOf("admin"),
+            issuer = "https://evil.example.com/realms/tenant-1"
+        )
+        get("/adminFunction", token).expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `token signed by another tenant key should be rejected with 401`() {
+        // claims to come from tenant-2 but is signed with the tenant-1 key: each tenant issuer must
+        // be verified against its own JWKS
+        val token = oidc.mintToken(
+            realm = TENANT_1,
+            roles = listOf("admin"),
+            issuer = oidc.issuer(TENANT_2)
+        )
+        get("/adminFunction", token).expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `malformed bearer token should be rejected with 401`() {
+        get("/securedFunction", "not-a-jwt").expectStatus().isUnauthorized
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/AuthFilterClaimIntegrationTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/AuthFilterClaimIntegrationTest.kt
@@ -1,0 +1,68 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * `f2.filter.*` entries are claim/value pairs every authenticated token must match to pass the
+ * mandatory-authentication rule of [WebSecurityConfig].
+ */
+@SpringBootTest(
+    classes = [AuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class AuthFilterClaimIntegrationTest {
+
+    companion object {
+        private const val REALM = "master"
+        private val oidc = OidcProviderStub(listOf(REALM))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("f2.issuers[0].name") { "first" }
+            registry.add("f2.issuers[0].auth-url") { oidc.authUrl }
+            registry.add("f2.issuers[0].realm") { REALM }
+            registry.add("f2.filter.azp") { "trusted-client" }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() = oidc.stop()
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    private fun getSecured(token: String) = webTestClient.get()
+        .uri("/securedFunction")
+        .headers { it.setBearerAuth(token) }
+        .exchange()
+
+    @Test
+    fun `token matching the configured claim filter should be accepted`() {
+        val token = oidc.mintToken(REALM, claims = mapOf("azp" to "trusted-client"))
+        getSecured(token).expectStatus().isOk
+    }
+
+    @Test
+    fun `token with a mismatching claim should be rejected with 403`() {
+        val token = oidc.mintToken(REALM, claims = mapOf("azp" to "other-client"))
+        getSecured(token).expectStatus().isForbidden
+    }
+
+    @Test
+    fun `token missing the filtered claim should be rejected with 403`() {
+        val token = oidc.mintToken(REALM)
+        getSecured(token).expectStatus().isForbidden
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/AuthTestApp.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/AuthTestApp.kt
@@ -1,0 +1,44 @@
+package io.komune.f2.spring.boot.auth.config
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.router
+
+/**
+ * Minimal reactive application wiring the real [WebSecurityConfig] filter chain, with one endpoint
+ * per authorization rule the config derives from bean annotations:
+ * - `openFunction`   -> `@PermitAll`
+ * - `adminFunction`  -> `@RolesAllowed("admin")`
+ * - `securedFunction` -> no annotation, falls through to the mandatory-authentication rule
+ */
+@SpringBootApplication
+class AuthTestApp {
+
+    @Configuration
+    @EnableConfigurationProperties(F2TrustedIssuersConfig::class)
+    class TestWebSecurityConfig : WebSecurityConfig()
+
+    @Bean("openFunction")
+    @PermitAll
+    fun openFunction(): () -> String = { "open" }
+
+    @Bean("adminFunction")
+    @RolesAllowed("admin")
+    fun adminFunction(): () -> String = { "admin" }
+
+    @Bean("securedFunction")
+    fun securedFunction(): () -> String = { "secured" }
+
+    @Bean
+    fun routes(): RouterFunction<ServerResponse> = router {
+        GET("/openFunction") { ServerResponse.ok().bodyValue("open") }
+        GET("/adminFunction") { ServerResponse.ok().bodyValue("admin") }
+        GET("/securedFunction") { ServerResponse.ok().bodyValue("secured") }
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/NoIssuerWebSecurityConfigIntegrationTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/NoIssuerWebSecurityConfigIntegrationTest.kt
@@ -1,0 +1,38 @@
+package io.komune.f2.spring.boot.auth.config
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * When no trusted issuer is configured, [WebSecurityConfig.dummyAuthenticationProvider] takes over
+ * and every exchange must be permitted (development / no-auth mode).
+ */
+@SpringBootTest(
+    classes = [AuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class NoIssuerWebSecurityConfigIntegrationTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    @Test
+    fun `secured path should be reachable without token when no issuer is configured`() {
+        webTestClient.get().uri("/securedFunction").exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("secured")
+    }
+
+    @Test
+    fun `RolesAllowed path should be reachable without token when no issuer is configured`() {
+        webTestClient.get().uri("/adminFunction").exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("admin")
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/OidcProviderStub.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/OidcProviderStub.kt
@@ -1,0 +1,107 @@
+package io.komune.f2.spring.boot.auth.config
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+
+/**
+ * In-process OpenID provider stub: serves an openid-configuration document and a JWKS per realm,
+ * and mints JWTs signed with the matching realm key.
+ *
+ * Everything is local (loopback HTTP + locally generated RSA keys), so no Keycloak instance and no
+ * network egress is needed to exercise the resource-server filter chain end to end.
+ */
+class OidcProviderStub(realms: List<String>) {
+
+    private val server: HttpServer = HttpServer.create(InetSocketAddress(0), 0)
+    private val keys: Map<String, RSAKey> = realms.associateWith { realm ->
+        RSAKeyGenerator(RSA_KEY_SIZE)
+            .keyID("$realm-key")
+            .generate()
+    }
+
+    val authUrl: String get() = "http://localhost:${server.address.port}/auth"
+
+    init {
+        realms.forEach { realm ->
+            val issuer = issuer(realm)
+            server.createContext("/auth/realms/$realm/.well-known/openid-configuration") { exchange ->
+                exchange.respondJson(
+                    """
+                    {
+                      "issuer": "$issuer",
+                      "jwks_uri": "$issuer/protocol/openid-connect/certs"
+                    }
+                    """.trimIndent()
+                )
+            }
+            server.createContext("/auth/realms/$realm/protocol/openid-connect/certs") { exchange ->
+                exchange.respondJson(JWKSet(keys.getValue(realm).toPublicJWK()).toString())
+            }
+        }
+        server.start()
+    }
+
+    fun issuer(realm: String) = "$authUrl/realms/$realm"
+
+    fun stop() = server.stop(0)
+
+    /**
+     * @param realm the realm whose signing key is used
+     * @param issuer the `iss` claim, defaults to the realm issuer. Override it to simulate a token
+     * claiming to come from another issuer while being signed by [realm]'s key.
+     */
+    @Suppress("LongParameterList")
+    fun mintToken(
+        realm: String,
+        roles: List<String> = emptyList(),
+        issuer: String = issuer(realm),
+        subject: String = "user-1",
+        claims: Map<String, Any> = emptyMap(),
+        expiresAt: Instant = Instant.now().plusSeconds(EXPIRY_SECONDS)
+    ): String {
+        val key = keys.getValue(realm)
+        val claimsSet = JWTClaimsSet.Builder()
+            .issuer(issuer)
+            .subject(subject)
+            .jwtID(UUID.randomUUID().toString())
+            .issueTime(Date.from(Instant.now().minusSeconds(EXPIRY_SECONDS)))
+            .expirationTime(Date.from(expiresAt))
+            .claim("realm_access", mapOf("roles" to roles))
+            .apply { claims.forEach { (name, value) -> claim(name, value) } }
+            .build()
+
+        val header = JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(key.keyID)
+            .type(JOSEObjectType.JWT)
+            .build()
+
+        return SignedJWT(header, claimsSet)
+            .apply { sign(RSASSASigner(key)) }
+            .serialize()
+    }
+
+    private fun HttpExchange.respondJson(body: String) {
+        val bytes = body.toByteArray()
+        responseHeaders.add("Content-Type", "application/json")
+        sendResponseHeaders(200, bytes.size.toLong())
+        responseBody.use { it.write(bytes) }
+    }
+
+    companion object {
+        private const val RSA_KEY_SIZE = 2048
+        private const val EXPIRY_SECONDS = 3600L
+    }
+}

--- a/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigIntegrationTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth/src/test/kotlin/io/komune/f2/spring/boot/auth/config/WebSecurityConfigIntegrationTest.kt
@@ -1,0 +1,140 @@
+package io.komune.f2.spring.boot.auth.config
+
+import java.time.Instant
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * End-to-end coverage of the security filter chain built by [WebSecurityConfig] when authentication
+ * is required (at least one trusted issuer configured). Tokens are minted locally by
+ * [OidcProviderStub], nothing leaves the loopback interface.
+ */
+@SpringBootTest(
+    classes = [AuthTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class WebSecurityConfigIntegrationTest {
+
+    companion object {
+        const val FIRST_REALM = "master"
+        const val SECOND_REALM = "tenant"
+
+        private val oidc = OidcProviderStub(listOf(FIRST_REALM, SECOND_REALM))
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun trustedIssuers(registry: DynamicPropertyRegistry) {
+            registry.add("f2.issuers[0].name") { "first" }
+            registry.add("f2.issuers[0].auth-url") { oidc.authUrl }
+            registry.add("f2.issuers[0].realm") { FIRST_REALM }
+            registry.add("f2.issuers[1].name") { "second" }
+            registry.add("f2.issuers[1].auth-url") { oidc.authUrl }
+            registry.add("f2.issuers[1].realm") { SECOND_REALM }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopOidcProviderStub() = oidc.stop()
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val webTestClient: WebTestClient by lazy {
+        WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    private fun get(path: String, token: String? = null) = webTestClient.get()
+        .uri(path)
+        .apply { token?.let { headers { headers -> headers.setBearerAuth(it) } } }
+        .exchange()
+
+    @Test
+    fun `unauthenticated request on a secured path should be rejected with 401`() {
+        get("/securedFunction").expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `unauthenticated request on a RolesAllowed path should be rejected with 401`() {
+        get("/adminFunction").expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `PermitAll path should be reachable without any token`() {
+        get("/openFunction")
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("open")
+    }
+
+    @Test
+    fun `authenticated request with an insufficient role should be rejected with 403`() {
+        val token = oidc.mintToken(FIRST_REALM, roles = listOf("user"))
+        get("/adminFunction", token).expectStatus().isForbidden
+    }
+
+    @Test
+    fun `authenticated request with the required role should be accepted`() {
+        val token = oidc.mintToken(FIRST_REALM, roles = listOf("admin"))
+        get("/adminFunction", token)
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("admin")
+    }
+
+    @Test
+    fun `authenticated request without any role should reach a path requiring only authentication`() {
+        val token = oidc.mintToken(FIRST_REALM)
+        get("/securedFunction", token)
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("secured")
+    }
+
+    @Test
+    fun `token issued by the second trusted issuer should be accepted`() {
+        val token = oidc.mintToken(SECOND_REALM, roles = listOf("admin"))
+        get("/adminFunction", token)
+            .expectStatus().isOk
+            .expectBody(String::class.java).isEqualTo("admin")
+    }
+
+    @Test
+    fun `token issued by an untrusted issuer should be rejected with 401`() {
+        val token = oidc.mintToken(
+            realm = FIRST_REALM,
+            roles = listOf("admin"),
+            issuer = "https://evil.example.com/realms/master"
+        )
+        get("/adminFunction", token).expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `token signed by another issuer key should be rejected with 401`() {
+        // claims to come from the second issuer but is signed with the first issuer key:
+        // the JWKS of the resolved issuer must be the one used for verification
+        val token = oidc.mintToken(
+            realm = FIRST_REALM,
+            roles = listOf("admin"),
+            issuer = oidc.issuer(SECOND_REALM)
+        )
+        get("/adminFunction", token).expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `expired token should be rejected with 401`() {
+        val token = oidc.mintToken(
+            realm = FIRST_REALM,
+            roles = listOf("admin"),
+            expiresAt = Instant.now().minusSeconds(600)
+        )
+        get("/adminFunction", token).expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `malformed bearer token should be rejected with 401`() {
+        get("/securedFunction", "not-a-jwt").expectStatus().isUnauthorized
+    }
+}


### PR DESCRIPTION
Closes #123

## What

The auth starters had no test that exercised the actual Spring Security filter chain. This adds `@SpringBootTest(webEnvironment = RANDOM_PORT)` + `WebTestClient` suites to the three reactive auth starters, driving the real chain with **locally minted RSA-signed JWTs**.

Token infrastructure: `OidcProviderStub` — a JDK `com.sun.net.httpserver.HttpServer` on a loopback port that serves an `openid-configuration` document and a JWKS per realm, plus Nimbus-signed tokens for those realms. **No Keycloak container, no network egress.**

### `f2-spring-boot-starter-auth` (16 new tests)
- `WebSecurityConfigIntegrationTest` (11): unauthenticated -> 401 (both on plain-secured and `@RolesAllowed` paths); `@PermitAll` bean path reachable with no token; authenticated with wrong role -> 403; correct role -> 200; **multi-issuer**: tokens from either configured issuer accepted, token from an unconfigured issuer -> 401, token claiming issuer B but signed with issuer A's key -> 401 (proves the resolved issuer's JWKS is the one used); expired token -> 401; malformed bearer -> 401.
- `AuthFilterClaimIntegrationTest` (3): `f2.filter.*` claim matching -> 200 on match, 403 on mismatch, 403 when the claim is absent.
- `NoIssuerWebSecurityConfigIntegrationTest` (2): with no `f2.issuers`, the dummy chain permits everything.

### `f2-spring-boot-starter-auth-tenant` (11 new tests)
- `TenantWebSecurityConfigIntegrationTest` (8): same 401/403/permitAll matrix plus multi-tenant resolution under `f2.tenant.issuer-base-uri` — both tenants accepted, issuer outside the base -> 401, cross-tenant key reuse -> 401.
- `TenantIssuerPrefixMatchingTest` (3): documents a **trust-boundary weakness**, see below.

### `f2-spring-boot-starter-auth-keycloak` (5 new tests)
`KeycloakConfigEndpointIntegrationTest`: `f2.issuers[*]` binding into `F2KeycloakConfig`/`KeycloakIssuers` (including the optional nested `web.client-id`) *and* simultaneously into `F2TrustedIssuersConfig`; endpoint resolution; and — through the live filter chain — `/keycloak` reachable anonymously thanks to its `@PermitAll` while other paths still return 401. Added `testImplementation(libs.spring.boot.starter.webflux)` for this (test-only).

## Finding: prefix-based issuer trust in the tenant starter

`TrustedIssuerJwtAuthenticationManagerResolver` (tenant) trusts an issuer via
`issuer.startsWith(trustedIssuersConfig.issuerBaseUri)` — a raw string prefix with no path-segment boundary. If `f2.tenant.issuer-base-uri` is configured **without a trailing separator**, a sibling issuer that merely shares the prefix is trusted: with base `.../realms/tenant-1`, a token from `.../realms/tenant-1-other` is accepted. `TenantIssuerPrefixMatchingTest` demonstrates this end to end.

Per the issue instructions I did **not** silently change the behaviour — the test asserts current behaviour and is commented as such, so any tightening is a deliberate decision. The base starter is not affected (it uses exact `issuer in trustedIssuers()` matching).

## Verification

Targeted module test tasks only:

- `./gradlew :f2-spring:auth:f2-spring-boot-starter-auth:test` -> 29 tests, 0 failures
- `./gradlew :f2-spring:auth:f2-spring-boot-starter-auth-tenant:test` -> 21 tests, 0 failures
- `./gradlew :f2-spring:auth:f2-spring-boot-starter-auth-keycloak:test` -> 11 tests, 0 failures
- `detekt` on the three modules: clean

All new tests passed on the first run — no behavioural regression surfaced in the starters other than the prefix-matching note above.