### PR TITLE
test: cover f2-feature-cloud-event-storming (19 tests)

### DIFF
--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/build.gradle.kts
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/build.gradle.kts
@@ -15,4 +15,7 @@ dependencies {
 
     implementation(libs.bundles.spring.data.commons)
     implementation(libs.jackson.module.kotlin)
+
+    testImplementation(libs.bundles.spring.test)
+    testImplementation(libs.spring.tx)
 }

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/F2StormingCloudEventConfigTest.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/F2StormingCloudEventConfigTest.kt
@@ -1,0 +1,73 @@
+package f2.feature.cloudEvent.storming
+
+import f2.feature.cloudEvent.storming.entity.CloudEventEntityRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.core.EntityInformation
+import org.springframework.data.repository.core.RepositoryInformation
+import org.springframework.data.repository.core.RepositoryMetadata
+import org.springframework.data.repository.core.support.ReactiveRepositoryFactorySupport
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+
+class F2StormingCloudEventConfigTest {
+
+    private val repository = InMemoryCloudEventEntityRepository()
+
+    /**
+     * The module does not bring a Spring Data module of its own: the repository is materialised from
+     * whatever [ReactiveRepositoryFactorySupport] the host application exposes. This stub only has to
+     * hand back a repository proxy for the requested interface.
+     */
+    private val repositoryFactory = object : ReactiveRepositoryFactorySupport() {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> getRepository(repositoryInterface: Class<T>): T {
+            check(repositoryInterface == CloudEventEntityRepository::class.java) {
+                "unexpected repository interface $repositoryInterface"
+            }
+            return repository as T
+        }
+
+        override fun getRepositoryBaseClass(metadata: RepositoryMetadata): Class<*> =
+            InMemoryCloudEventEntityRepository::class.java
+
+        override fun getTargetRepository(metadata: RepositoryInformation): Any = repository
+
+        override fun getEntityInformation(
+            metadata: RepositoryMetadata
+        ): EntityInformation<*, *> = throw UnsupportedOperationException("not needed by the test")
+    }
+
+    private val config = F2StormingCloudEventConfig()
+
+    @Test
+    fun `cloudEventEntityRepository should be built from the reactive repository factory`() {
+        assertThat(config.cloudEventEntityRepository(repositoryFactory)).isSameAs(repository)
+    }
+
+    @Test
+    fun `stormingCommandSink should be wired with the repository`() {
+        val objectMapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
+
+        config.stormingCommandSink(repository, objectMapper)
+            .storeCommand(CreateUserCommand(name = "john", age = 42))
+            .block()
+
+        assertThat(repository.saved).hasSize(1)
+    }
+
+    @Test
+    fun `stormingCloudEventSink should be wired with the repository`() {
+        val event = f2.dsl.event.CloudEvent(
+            eventType = "UserCreated",
+            cloudEventsVersion = "1",
+            source = "S2",
+            eventID = "event-1",
+            data = """{"name":"john"}"""
+        )
+
+        config.stormingCloudEventSink(repository).storeCommand(event).block()
+
+        assertThat(repository.saved.single().event).isSameAs(event)
+    }
+}

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/InMemoryCloudEventEntityRepository.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/InMemoryCloudEventEntityRepository.kt
@@ -1,0 +1,77 @@
+package f2.feature.cloudEvent.storming
+
+import f2.feature.cloudEvent.storming.entity.CloudEventEntity
+import f2.feature.cloudEvent.storming.entity.CloudEventEntityRepository
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/**
+ * In-memory stand-in for the reactive repository, so the sinks and the supplier can be exercised
+ * without a database. The module declares no R2DBC driver: the repository is built at runtime from
+ * the host application's [org.springframework.data.repository.core.support.ReactiveRepositoryFactorySupport].
+ */
+class InMemoryCloudEventEntityRepository : CloudEventEntityRepository {
+
+    /** Entities actually written, i.e. for which the returned [Mono] has been subscribed. */
+    val saved = mutableListOf<CloudEventEntity>()
+
+    /** Number of `save` calls, whether or not the returned [Mono] has been subscribed. */
+    var saveInvocations = 0
+
+    override fun <S : CloudEventEntity> save(entity: S): Mono<S> {
+        saveInvocations++
+        return Mono.fromCallable {
+            saved.add(entity)
+            entity
+        }
+    }
+
+    override fun <S : CloudEventEntity> saveAll(entities: MutableIterable<S>): Flux<S> =
+        Flux.fromIterable(entities).flatMap { save(it) }
+
+    override fun <S : CloudEventEntity> saveAll(entityStream: Publisher<S>): Flux<S> =
+        Flux.from(entityStream).flatMap { save(it) }
+
+    override fun findAll(): Flux<CloudEventEntity> = Flux.fromIterable(saved.toList())
+
+    override fun findById(id: String): Mono<CloudEventEntity> =
+        Mono.justOrEmpty(saved.firstOrNull { it.id.toString() == id })
+
+    override fun findById(id: Publisher<String>): Mono<CloudEventEntity> =
+        Mono.from(id).flatMap(::findById)
+
+    override fun existsById(id: String): Mono<Boolean> = findById(id).hasElement()
+
+    override fun existsById(id: Publisher<String>): Mono<Boolean> = findById(id).hasElement()
+
+    override fun findAllById(ids: MutableIterable<String>): Flux<CloudEventEntity> =
+        Flux.fromIterable(ids).flatMap(::findById)
+
+    override fun findAllById(idStream: Publisher<String>): Flux<CloudEventEntity> =
+        Flux.from(idStream).flatMap(::findById)
+
+    override fun count(): Mono<Long> = Mono.fromCallable { saved.size.toLong() }
+
+    override fun deleteById(id: String): Mono<Void> = Mono.fromRunnable {
+        saved.removeIf { it.id.toString() == id }
+    }
+
+    override fun deleteById(id: Publisher<String>): Mono<Void> =
+        Mono.from(id).flatMap(::deleteById).then()
+
+    override fun delete(entity: CloudEventEntity): Mono<Void> = Mono.fromRunnable {
+        saved.remove(entity)
+    }
+
+    override fun deleteAllById(ids: MutableIterable<String>): Mono<Void> =
+        Flux.fromIterable(ids).flatMap(::deleteById).then()
+
+    override fun deleteAll(entities: MutableIterable<CloudEventEntity>): Mono<Void> =
+        Flux.fromIterable(entities).flatMap(::delete).then()
+
+    override fun deleteAll(entityStream: Publisher<out CloudEventEntity>): Mono<Void> =
+        Flux.from(entityStream).flatMap(::delete).then()
+
+    override fun deleteAll(): Mono<Void> = Mono.fromRunnable { saved.clear() }
+}

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCloudEventFunctionTest.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCloudEventFunctionTest.kt
@@ -1,0 +1,49 @@
+package f2.feature.cloudEvent.storming
+
+import f2.dsl.event.CloudEvent
+import f2.feature.cloudEvent.storming.entity.CloudEventEntity
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StormingCloudEventFunctionTest {
+
+    private val repository = InMemoryCloudEventEntityRepository()
+    private val supplier = StormingCloudEventFunction().cloudEvents(repository)
+
+    private fun store(eventId: String) {
+        val event = CloudEvent(
+            eventType = "UserCreated",
+            cloudEventsVersion = "1",
+            source = "S2",
+            eventID = eventId,
+            data = """{"name":"john"}"""
+        )
+        repository.save(CloudEventEntity(id = UUID.randomUUID(), event = event)).block()
+    }
+
+    @Test
+    fun `cloudEvents should emit nothing when no event is stored`() {
+        assertThat(supplier.get().collectList().block()).isEmpty()
+    }
+
+    @Test
+    fun `cloudEvents should emit the stored events`() {
+        store("event-1")
+        store("event-2")
+
+        val events = supplier.get().collectList().block()!!
+
+        assertThat(events.map { it.eventID }).containsExactly("event-1", "event-2")
+        assertThat(events.map { it.eventType }).containsOnly("UserCreated")
+    }
+
+    @Test
+    fun `cloudEvents supplier should re-read the repository on each get`() {
+        store("event-1")
+        assertThat(supplier.get().collectList().block()).hasSize(1)
+
+        store("event-2")
+        assertThat(supplier.get().collectList().block()).hasSize(2)
+    }
+}

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCloudEventSinkTest.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCloudEventSinkTest.kt
@@ -1,0 +1,48 @@
+package f2.feature.cloudEvent.storming
+
+import f2.dsl.event.CloudEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StormingCloudEventSinkTest {
+
+    private val repository = InMemoryCloudEventEntityRepository()
+    private val sink = StormingCloudEventSink(repo = repository)
+
+    private fun cloudEvent(id: String) = CloudEvent(
+        eventType = "UserCreated",
+        eventTypeVersion = "1",
+        cloudEventsVersion = "1",
+        source = "S2",
+        eventID = id,
+        data = """{"name":"john"}"""
+    )
+
+    @Test
+    fun `storeCommand should persist the incoming cloud event as is`() {
+        val event = cloudEvent("event-1")
+
+        sink.storeCommand(event).block()
+
+        assertThat(repository.saved.single().event).isSameAs(event)
+    }
+
+    @Test
+    fun `storeCommand should assign a distinct entity id to each event`() {
+        sink.storeCommand(cloudEvent("event-1")).block()
+        sink.storeCommand(cloudEvent("event-2")).block()
+
+        assertThat(repository.saved).hasSize(2)
+        assertThat(repository.saved.map { it.id }).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `storeCommand currently returns a cold Mono and persists nothing until it is subscribed`() {
+        // same defect as StormingCommandSink: the Mono returned by `repo.save` is never subscribed
+        // when Spring invokes the @EventListener. Documented as-is, see issue #130.
+        sink.storeCommand(cloudEvent("event-1"))
+
+        assertThat(repository.saveInvocations).isEqualTo(1)
+        assertThat(repository.saved).isEmpty()
+    }
+}

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCommandSinkTest.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingCommandSinkTest.kt
@@ -1,0 +1,91 @@
+package f2.feature.cloudEvent.storming
+
+import f2.dsl.cqrs.Command
+import java.time.Instant
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+
+data class CreateUserCommand(val name: String, val age: Int) : Command
+data class DeleteUserCommand(val id: String) : Command
+
+class StormingCommandSinkTest {
+
+    private val objectMapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
+    private val repository = InMemoryCloudEventEntityRepository()
+    private val sink = StormingCommandSink(repo = repository, objectMapper = objectMapper)
+
+    @Test
+    fun `storeCommand should persist one cloud event per command`() {
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42)).block()
+
+        assertThat(repository.saved).hasSize(1)
+    }
+
+    @Test
+    fun `storeCommand should use the command class simple name as event type`() {
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42)).block()
+
+        assertThat(repository.saved.single().event.eventType).isEqualTo("CreateUserCommand")
+    }
+
+    @Test
+    fun `storeCommand should serialize the command as json payload`() {
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42)).block()
+
+        assertThat(repository.saved.single().event.data)
+            .isEqualTo("""{"name":"john","age":42}""")
+    }
+
+    @Test
+    fun `storeCommand should fill the cloud event envelope`() {
+        sink.storeCommand(DeleteUserCommand(id = "user-1")).block()
+
+        val event = repository.saved.single().event
+        assertThat(event.source).isEqualTo("S2")
+        assertThat(event.cloudEventsVersion).isEqualTo("1")
+        assertThat(event.eventTypeVersion).isEqualTo("1")
+        assertThat(event.contentType).isEqualTo("application/json")
+        assertThat(event.schemaURL).isNull()
+        assertThat(event.extensions).isNull()
+    }
+
+    @Test
+    fun `storeCommand should generate a unique id for the event and the entity`() {
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42)).block()
+        sink.storeCommand(CreateUserCommand(name = "jane", age = 24)).block()
+
+        val entities = repository.saved
+        assertThat(entities).hasSize(2)
+        assertThat(entities.map { it.id }).doesNotHaveDuplicates()
+        assertThat(entities.map { it.event.eventID }).doesNotHaveDuplicates()
+        entities.forEach { entity ->
+            assertThat(UUID.fromString(entity.event.eventID)).isNotNull
+        }
+    }
+
+    @Test
+    fun `storeCommand currently returns a cold Mono and persists nothing until it is subscribed`() {
+        // `storeCommand` ends with `repo.save(entity)` inside `runBlocking`, which only *builds* the
+        // Mono: nothing is awaited nor subscribed. Spring's event multicaster discards the returned
+        // value, so with a real reactive repository no row is ever written.
+        // Documented as-is, see issue #130.
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42))
+
+        assertThat(repository.saveInvocations).isEqualTo(1)
+        assertThat(repository.saved).isEmpty()
+    }
+
+    @Test
+    fun `storeCommand should timestamp the event with an RFC 3339 instant`() {
+        val before = Instant.now().minusSeconds(1)
+
+        sink.storeCommand(CreateUserCommand(name = "john", age = 42)).block()
+
+        val eventTime = Instant.parse(repository.saved.single().event.eventTime)
+        assertThat(eventTime).isAfterOrEqualTo(before)
+        assertThat(eventTime).isBeforeOrEqualTo(Instant.now().plusSeconds(1))
+    }
+}

--- a/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingEventListenerWiringTest.kt
+++ b/f2-feature/cloud-event-storming/f2-feature-cloud-event-storming/src/test/kotlin/f2/feature/cloudEvent/storming/StormingEventListenerWiringTest.kt
@@ -1,0 +1,79 @@
+package f2.feature.cloudEvent.storming
+
+import f2.dsl.event.CloudEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+
+/**
+ * Checks that the `@EventListener` methods of both sinks are actually wired by the Spring event
+ * multicaster: publishing a [f2.dsl.cqrs.Command] or a [CloudEvent] must reach the matching sink.
+ */
+class StormingEventListenerWiringTest {
+
+    @Configuration
+    open class SinksConfig {
+        @Bean
+        open fun repository() = InMemoryCloudEventEntityRepository()
+
+        @Bean
+        open fun objectMapper() = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
+
+        @Bean
+        open fun stormingCommandSink(
+            repository: InMemoryCloudEventEntityRepository,
+            objectMapper: tools.jackson.databind.ObjectMapper
+        ) = StormingCommandSink(repo = repository, objectMapper = objectMapper)
+
+        @Bean
+        open fun stormingCloudEventSink(repository: InMemoryCloudEventEntityRepository) =
+            StormingCloudEventSink(repo = repository)
+    }
+
+    private lateinit var context: AnnotationConfigApplicationContext
+    private lateinit var repository: InMemoryCloudEventEntityRepository
+
+    @BeforeEach
+    fun setUp() {
+        context = AnnotationConfigApplicationContext(SinksConfig::class.java)
+        repository = context.getBean(InMemoryCloudEventEntityRepository::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() = context.close()
+
+    @Test
+    fun `publishing a command should reach the command sink`() {
+        context.publishEvent(CreateUserCommand(name = "john", age = 42))
+
+        assertThat(repository.saveInvocations).isEqualTo(1)
+    }
+
+    @Test
+    fun `publishing a cloud event should reach the cloud event sink`() {
+        context.publishEvent(
+            CloudEvent(
+                eventType = "UserCreated",
+                cloudEventsVersion = "1",
+                source = "S2",
+                eventID = "event-1",
+                data = """{"name":"john"}"""
+            )
+        )
+
+        assertThat(repository.saveInvocations).isEqualTo(1)
+    }
+
+    @Test
+    fun `publishing an unrelated event should reach no sink`() {
+        context.publishEvent("some-unrelated-payload")
+
+        assertThat(repository.saveInvocations).isZero()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-b
 # Spring Framework
 spring-context = { group = "org.springframework", name = "spring-context" }
 spring-web = { group = "org.springframework", name = "spring-web" }
+spring-tx = { group = "org.springframework", name = "spring-tx" }
 spring-data-commons = { group = "org.springframework.data", name = "spring-data-commons" }
 
 # Spring Security


### PR DESCRIPTION
Closes #130

## What

19 tests covering all 6 source files of the module, which had none.

- `StormingCommandSinkTest` (7) — the `Command` -> `CloudEvent` mapping: `eventType` from the command class simple name, JSON payload, envelope fields (`source`, versions, `contentType`, null `schemaURL`/`extensions`), unique entity/event ids, RFC 3339 `eventTime`.
- `StormingCloudEventSinkTest` (3) — incoming `CloudEvent` stored as-is under a fresh entity id.
- `StormingCloudEventFunctionTest` (3) — the `cloudEvents` supplier maps repository rows to events and re-reads on each `get()`.
- `F2StormingCloudEventConfigTest` (3) — the three `@Bean` methods, including the repository being obtained from the injected `ReactiveRepositoryFactorySupport`.
- `StormingEventListenerWiringTest` (3) — Spring slice test: publishing a `Command` reaches the command sink, publishing a `CloudEvent` reaches the cloud-event sink, an unrelated payload reaches neither.

### No database needed

The issue suggested H2/testcontainers for `CloudEventEntityRepository`. That turned out not to apply: the module declares **no** Spring Data module or R2DBC driver — `CloudEventEntityRepository` is a bare `ReactiveCrudRepository` interface materialised at runtime from whatever `ReactiveRepositoryFactorySupport` the *host* application exposes. There is nothing module-local to run against a database, so the tests use `InMemoryCloudEventEntityRepository`, a hand-written fake in the repo's existing "hand-rolled test double" style. **No Docker involved.**

## Findings (documented, not fixed)

1. **The sinks persist nothing.** Both `StormingCommandSink.storeCommand` and `StormingCloudEventSink.storeCommand` end with `runBlocking { ... repo.save(entity) }`. `runBlocking` returns the *cold* `Mono` without subscribing to it, and Spring's event multicaster discards an `@EventListener` return value — so with a real reactive repository no row is ever written. Two tests (`storeCommand currently returns a cold Mono and persists nothing until it is subscribed`) assert the current behaviour explicitly, with a comment pointing at this issue. Fix would be `repo.save(entity).awaitSingle()` (or `.subscribe()`), left out deliberately.
2. **Id type mismatch**: `CloudEventEntityRepository : ReactiveCrudRepository<CloudEventEntity, String>` while `CloudEventEntity.id` is a `UUID`.
3. **`CloudEventEntity` is annotated with JPA's `jakarta.persistence.@Entity`** while being used through a *reactive* repository, and `event: CloudEvent<*>` has no converter — it cannot map to a relational column as-is.

## Build changes

- `testImplementation(libs.bundles.spring.test)` on the module (it had no test deps at all).
- `testImplementation(libs.spring.tx)` — needed on the test classpath to instantiate `ReactiveRepositoryFactorySupport` (`org.springframework.dao.*`); added `spring-tx` to `gradle/libs.versions.toml` rather than a raw coordinate, per repo convention.

## Not done

The issue's "broaden catalog/version coverage" side note is out of scope here — those modules do have tests (3 and 4 respectively); this PR is the zero-coverage module.

## Verification

`./gradlew :f2-feature:cloud-event-storming:f2-feature-cloud-event-storming:test` -> 19 tests, 0 failures. `detekt` on the module: clean.