### PR TITLE
fix: require a path-segment boundary when matching trusted tenant issuers

### DIFF
--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/main/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolver.kt
@@ -22,8 +22,10 @@ class TrustedIssuerJwtAuthenticationManagerResolver(
 
     private val authenticationManagers: MutableMap<String, Mono<ReactiveAuthenticationManager>> = ConcurrentHashMap()
 
+    private val issuerBaseUri = trustedIssuersConfig.issuerBaseUri.trimEnd('/')
+
     override fun resolve(issuer: String): Mono<ReactiveAuthenticationManager> {
-        if (!issuer.startsWith(trustedIssuersConfig.issuerBaseUri)) return Mono.empty()
+        if (!isTrustedIssuer(issuer)) return Mono.empty()
         return this.authenticationManagers.computeIfAbsent(issuer) {
             buildAuthenticationManager(issuer).subscribeOn(Schedulers.boundedElastic())
                 .cache(
@@ -32,6 +34,21 @@ class TrustedIssuerJwtAuthenticationManagerResolver(
                     /* ttlForEmpty = */ { Duration.ZERO }
                 )
         }
+    }
+
+    /**
+     * An issuer is trusted only when it is the configured `f2.tenant.issuer-base-uri` itself, or one
+     * of its descendants: the base URI must be followed by a path separator, so a sibling merely
+     * sharing the prefix (`.../realms/tenant-1-other` for base `.../realms/tenant-1`) is not trusted.
+     *
+     * Trailing slashes are ignored on both sides, so `.../realms` and `.../realms/` describe the same
+     * trust set. An empty base URI trusts nothing (the tenant filter chain is not active in that case
+     * anyway, see `AUTHENTICATION_REQUIRED_EXPRESSION`).
+     */
+    fun isTrustedIssuer(issuer: String): Boolean {
+        if (issuerBaseUri.isEmpty()) return false
+        val candidate = issuer.trimEnd('/')
+        return candidate == issuerBaseUri || candidate.startsWith("$issuerBaseUri/")
     }
 
     private fun buildAuthenticationManager(issuer: String) = Mono.fromCallable<ReactiveAuthenticationManager> {

--- a/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
+++ b/f2-spring/auth/f2-spring-boot-starter-auth-tenant/src/test/kotlin/io/komune/f2/spring/boot/auth/security/TrustedIssuerJwtAuthenticationManagerResolverTest.kt
@@ -16,6 +16,9 @@ class TrustedIssuerJwtAuthenticationManagerResolverTest {
     companion object {
         private const val TENANT_PATH = "/auth/realms/tenant-1"
 
+        /** Base URI of issuers that are never dereferenced: only the trust decision is asserted. */
+        private const val AUTH_BASE_URI = "https://auth.example.org/auth"
+
         private lateinit var server: HttpServer
         private lateinit var issuerBaseUri: String
         private lateinit var trustedIssuer: String
@@ -75,6 +78,77 @@ class TrustedIssuerJwtAuthenticationManagerResolverTest {
         val second = resolver.resolve(trustedIssuer)
         assertThat(second).isSameAs(first)
     }
+
+    @Test
+    fun `resolve should return empty mono for a sibling issuer merely sharing the base uri prefix`() {
+        val singleTenantResolver = resolverWithBaseUri(trustedIssuer)
+
+        assertThat(singleTenantResolver.resolve("$trustedIssuer-other").block()).isNull()
+        assertThat(singleTenantResolver.resolve(trustedIssuer).block()).isNotNull
+    }
+
+    @Test
+    fun `a tenant base uri should only trust that tenant and its sub paths`() {
+        val singleTenantResolver = resolverWithBaseUri("$AUTH_BASE_URI/realms/tenant-1")
+
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-1")).isTrue()
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-1/")).isTrue()
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-1/sub")).isTrue()
+
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-1-other")).isFalse()
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-10")).isFalse()
+        assertThat(singleTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-2")).isFalse()
+    }
+
+    @Test
+    fun `a trailing slash on the base uri should not change the trust set`() {
+        val withSlash = resolverWithBaseUri("$AUTH_BASE_URI/realms/tenant-1/")
+        val withoutSlash = resolverWithBaseUri("$AUTH_BASE_URI/realms/tenant-1")
+
+        listOf(
+            "$AUTH_BASE_URI/realms/tenant-1",
+            "$AUTH_BASE_URI/realms/tenant-1/",
+            "$AUTH_BASE_URI/realms/tenant-1-other",
+            "$AUTH_BASE_URI/realms/tenant-2"
+        ).forEach { issuer ->
+            assertThat(withSlash.isTrustedIssuer(issuer))
+                .describedAs(issuer)
+                .isEqualTo(withoutSlash.isTrustedIssuer(issuer))
+        }
+    }
+
+    @Test
+    fun `a realms base uri should trust every realm under it but nothing beside it`() {
+        val multiTenantResolver = resolverWithBaseUri("$AUTH_BASE_URI/realms")
+
+        assertThat(multiTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-1")).isTrue()
+        assertThat(multiTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms/tenant-2")).isTrue()
+
+        assertThat(multiTenantResolver.isTrustedIssuer("$AUTH_BASE_URI/realms-other/tenant-1")).isFalse()
+    }
+
+    @Test
+    fun `a host level base uri should not trust a look-alike host`() {
+        val hostResolver = resolverWithBaseUri("https://auth.example.org")
+
+        assertThat(hostResolver.isTrustedIssuer("https://auth.example.org/auth/realms/tenant-1")).isTrue()
+        assertThat(hostResolver.isTrustedIssuer("https://auth.example.org")).isTrue()
+
+        assertThat(hostResolver.isTrustedIssuer("https://auth.example.org.evil.tld/auth/realms/tenant-1")).isFalse()
+        assertThat(hostResolver.isTrustedIssuer("https://auth.example.org.evil.tld")).isFalse()
+    }
+
+    @Test
+    fun `an empty base uri should trust nothing`() {
+        val emptyResolver = resolverWithBaseUri("")
+
+        assertThat(emptyResolver.isTrustedIssuer("https://auth.example.org/auth/realms/tenant-1")).isFalse()
+        assertThat(emptyResolver.resolve("https://auth.example.org/auth/realms/tenant-1").block()).isNull()
+    }
+
+    private fun resolverWithBaseUri(baseUri: String) = TrustedIssuerJwtAuthenticationManagerResolver(
+        trustedIssuersConfig = F2TrustedIssuersConfig(issuerBaseUri = baseUri)
+    )
 
     @Test
     fun `jwtAuthoritiesConverter should map realm_access roles to prefixed authorities`() {


### PR DESCRIPTION
Closes #139.

## What changed

`TrustedIssuerJwtAuthenticationManagerResolver` (tenant starter) decided trust with a raw
`issuer.startsWith(issuerBaseUri)`, i.e. no path-segment nor host boundary. A base pinned to a single
realm (`.../realms/tenant-1`) therefore also trusted a sibling realm sharing that prefix
(`.../realms/tenant-1-other`), whose tokens are then validated against their own JWKS and whose
`realm_access.roles` are mapped to authorities — a multi-tenant isolation break. A base stopping at
the host trusted look-alike hosts the same way.

The trust rule is now:

```kotlin
private val issuerBaseUri = trustedIssuersConfig.issuerBaseUri.trimEnd('/')

fun isTrustedIssuer(issuer: String): Boolean {
    if (issuerBaseUri.isEmpty()) return false
    val candidate = issuer.trimEnd('/')
    return candidate == issuerBaseUri || candidate.startsWith("$issuerBaseUri/")
}
```

**Design choice.** I kept prefix semantics rather than switching to an exact issuer set like the
non-tenant starter (`f2-spring-boot-starter-auth`, `WebSecurityConfig.isTrustedIssuer`): the whole
point of this starter is that one property covers an open-ended set of realms
(`f2.tenant.issuer-base-uri = .../auth/realms/`), and an exact set would remove that. What was
missing is only the boundary — the base URI must be followed by `/` — plus trailing-slash
normalisation so `.../realms` and `.../realms/` describe the same trust set. Empty base now trusts
nothing instead of everything (defence in depth; unreachable through the starter, whose secure chain
is only active when the property is non-empty).

The non-tenant starter was checked and is not affected: it matches issuers exactly.

## How it was verified

Targeted only, no full build:

* `./gradlew :f2-spring:auth:f2-spring-boot-starter-auth-tenant:test` — 12 tests, 0 failures.
* `./gradlew :f2-spring:auth:f2-spring-boot-starter-auth-tenant:detekt` — clean.
* Counter-check: with the trust rule temporarily reverted to `startsWith`, the 6 new tests fail
  (and only those), so they do pin the fix rather than the implementation.

New tests on `TrustedIssuerJwtAuthenticationManagerResolverTest`: a `tenant-1` base rejects
`tenant-1-other`/`tenant-10`/`tenant-2` and accepts `tenant-1`, `tenant-1/` and sub-paths;
`resolve()` returns an empty `Mono` for the sibling issuer; a base with and without a trailing slash
give identical decisions; a `.../realms` base trusts realms under it but not `.../realms-other/...`;
a host-level base rejects a look-alike host; an empty base trusts nothing.

## Merge order caveat (deliberate conflict)

PR #135 adds `TenantIssuerPrefixMatchingTest`, which **pins the vulnerable behaviour** — notably
`token of a sibling issuer sharing the base uri prefix is currently accepted` expects `200`. This
branch is off `origin/main` and does not contain that test, so nothing conflicts textually today.

**Merge #135 first**, then merge this PR and update the now-obsolete assertions in
`TenantIssuerPrefixMatchingTest`: the sibling-issuer case must expect `401` (rename the test
accordingly), while `token of the configured tenant should be accepted` and the unrelated-issuer
case stay as they are. This is known and intentional, not an accident.
