### PR TITLE
ci: add concurrency group to dev.yml to cancel superseded PR runs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,11 +11,13 @@ on:
       - main
       - 'release/*'
 
-# Only cancel superseded pull request runs. Pushes to main, release branches and
-# scheduled runs queue instead, so a publish is never interrupted mid-flight.
+# Cancel only superseded pull request runs that cannot publish: PRs labeled
+# 'stage' and versioning/* release PRs run the stage task, so they queue —
+# like pushes, scheduled and manually dispatched runs — instead of being
+# cancelled mid-publish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'stage') && !startsWith(github.head_ref, 'versioning/') }}
 
 jobs:
   libs:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,6 +11,12 @@ on:
       - main
       - 'release/*'
 
+# Only cancel superseded pull request runs. Pushes to main, release branches and
+# scheduled runs queue instead, so a publish is never interrupted mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   libs:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main


### PR DESCRIPTION
Ports [fixers-gradle#210](https://github.com/komune-io/fixers-gradle/pull/210) to this repo.

- PR pushes cancel their own superseded runs (`refs/pull/N/merge` groups — only same-PR runs affect each other).
- Pushes to `main`/`release/*`, scheduled and dispatched runs are never cancelled: `cancel-in-progress` evaluates false for them, so they queue instead of overlapping. This also prevents the concurrent-`stage`-upload pile-up that triggered GitHub Packages 403 rate limiting on fixers-gradle main (2026-08-13).
- Deliberately in the caller workflow, not the reusable ones: inside a `workflow_call` workflow `github.workflow` resolves to the caller's name, so groups there would collide across callers.

Known GitHub semantics: a non-cancelling group keeps at most one queued run — on a rapid double-merge to main the middle run is superseded and only HEAD publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow handling by cancelling superseded development runs when applicable.
  * Preserved active runs for staged changes and versioning branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->