### PR TITLE
ci: grant packages read for the Dependabot regen workflow

### DIFF
--- a/.github/workflows/dependabot-verification.yml
+++ b/.github/workflows/dependabot-verification.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   actions: write
   pull-requests: write
+  packages: read
 
 jobs:
   regenerate:


### PR DESCRIPTION
Companion to [fixers-gradle#235](https://github.com/komune-io/fixers-gradle/pull/235): the regen resolves io.komune snapshots from GitHub Packages, which needs authentication; the reusable's regenerate job now uses a read-only downgraded token, and a reusable job can only downgrade what the caller grants — hence `packages: read` here. Merge after fixers-gradle#235.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to enable read-only access to package information during pull request verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->