### PR TITLE
ci: suppress S7637 on org-internal reusable workflow references

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   libs:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main # NOSONAR(githubactions:S7637) org-internal reusable, tracked @main by convention
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Main's SonarCloud new-code security rating is C: `githubactions:S7637` (SHA-pin the `uses:` reference) fires on the `komune-io/fixers-gradle/...@main` lines in dev.yml, which recent edits pulled into the new-code window. These references are deliberately `@main` — org convention so central fixes propagate to all callers — the same decision already documented and suppressed on the dependabot-verification callers.

Adds the inline `# NOSONAR(githubactions:S7637)` markers with rationale. Restores the main gate to A on the next analysis.